### PR TITLE
Add missing `resh` call and use static login/db name

### DIFF
--- a/docs/getting-started/installing-with-kubernetes.md
+++ b/docs/getting-started/installing-with-kubernetes.md
@@ -46,15 +46,13 @@
     Set up a database and password:
 
     ```bash
-    RESOTOCORE_GRAPHDB_LOGIN=resoto
-    RESOTOCORE_GRAPHDB_DATABASE=resoto
     RESOTOCORE_GRAPHDB_PASSWORD=$(head -c 1500 /dev/urandom | tr -dc 'a-zA-Z0-9' | cut -c -32)
     POD=$(kubectl get pods --selector=arango_deployment=single-server -o jsonpath="{.items[0].metadata.name}")
     kubectl exec -i ${POD} -- arangosh --console.history false --server.password "" <<EOF
         const users = require('@arangodb/users');
-        users.save('$RESOTOCORE_GRAPHDB_LOGIN', '$RESOTOCORE_GRAPHDB_PASSWORD');
-        db._createDatabase('$RESOTOCORE_GRAPHDB_DATABASE');
-        users.grantDatabase('$RESOTOCORE_GRAPHDB_LOGIN', '$RESOTOCORE_GRAPHDB_DATABASE', 'rw');
+        users.save('resoto', '$RESOTOCORE_GRAPHDB_PASSWORD');
+        db._createDatabase('resoto');
+        users.grantDatabase('resoto', '$RESOTOCORE_GRAPHDB_DATABASE', 'rw');
     EOF
     ```
 
@@ -70,8 +68,8 @@
     resotocore:
       graphdb:
         server: http://single-server:8529
-        login: $RESOTOCORE_GRAPHDB_LOGIN
-        database: $RESOTOCORE_GRAPHDB_DATABASE
+        login: resoto
+        database: resoto
         passwordSecret:
           name: resoto-graphdb-credentials
           key: password
@@ -160,7 +158,7 @@
 To access the Resoto shell interface, simply execute the following command:
 
 ```bash
-
+resh
 ```
 
 ## Resoto Web UI

--- a/docs/getting-started/installing-with-kubernetes.md
+++ b/docs/getting-started/installing-with-kubernetes.md
@@ -52,7 +52,7 @@
         const users = require('@arangodb/users');
         users.save('resoto', '$RESOTOCORE_GRAPHDB_PASSWORD');
         db._createDatabase('resoto');
-        users.grantDatabase('resoto', '$RESOTOCORE_GRAPHDB_DATABASE', 'rw');
+        users.grantDatabase('resoto', 'resoto', 'rw');
     EOF
     ```
 


### PR DESCRIPTION
# Description

The call to `resh` was empty.
Also it would make sense to use static login/dbname resoto instead of assigning shell variables because further down in the yaml file we do not make it clear to the user that they have to substitute those values manually with the ones previously generated.
This way they can just copy'paste the file and it'll work.
