### PR TITLE
feat: Add release notes for 2.0.0a14 and a script to create release notes

### DIFF
--- a/news/2022-02-02-v2.0.0.14.md
+++ b/news/2022-02-02-v2.0.0.14.md
@@ -1,0 +1,27 @@
+# 2.0.0a14
+
+Highlight of this release: we now have a docker-compose file, so each component is started as separate process.
+
+## Features
+
+- [`9abb8a43`](https://github.com/someengineering/resoto/commit/9abb8a43) <span class="badge badge--secondary">docker</span> Pin compose to next tagged version ([#611](https://github.com/someengineering/resoto/pull/611))
+- [`4a660403`](https://github.com/someengineering/resoto/commit/4a660403) <span class="badge badge--secondary">docker</span> Initial docker-compose.yml ([#599](https://github.com/someengineering/resoto/pull/599))
+- [`66eef944`](https://github.com/someengineering/resoto/commit/66eef944) <span class="badge badge--secondary">resotoworker</span> Create tempfile with graph ndjson before sending to core ([#608](https://github.com/someengineering/resoto/pull/608))
+- [`fa8d9f35`](https://github.com/someengineering/resoto/commit/fa8d9f35) <span class="badge badge--secondary">resotoworker</span> Let user choose kind to merge at ([#605](https://github.com/someengineering/resoto/pull/605))
+- [`9ced8ef4`](https://github.com/someengineering/resoto/commit/9ced8ef4) <span class="badge badge--secondary">resotocore</span> Tag update allows format like templating ([#600](https://github.com/someengineering/resoto/pull/600))
+- [`282bbecf`](https://github.com/someengineering/resoto/commit/282bbecf) <span class="badge badge--secondary">resotocore</span> List cli commands and replacements via API ([#592](https://github.com/someengineering/resoto/pull/592))
+
+## Chores
+
+- [`d4b2a55f`](https://github.com/someengineering/resoto/commit/d4b2a55f) <span class="badge badge--secondary">resotocore</span> Mark experimental API ([#603](https://github.com/someengineering/resoto/pull/603))
+- [`f157192e`](https://github.com/someengineering/resoto/commit/f157192e) <span class="badge badge--secondary">resoto</span> Fix test dependencies in tox ([#604](https://github.com/someengineering/resoto/pull/604))
+- [`d9409de4`](https://github.com/someengineering/resoto/commit/d9409de4) <span class="badge badge--secondary">resoto</span> Bump 2.0.0a14 ([#597](https://github.com/someengineering/resoto/pull/597))
+- [`e5317c30`](https://github.com/someengineering/resoto/commit/e5317c30) <span class="badge badge--secondary">helm</span> Update helm chart appVersion ([#610](https://github.com/someengineering/resoto/pull/610))
+
+## Fixes
+
+- [`85337243`](https://github.com/someengineering/resoto/commit/85337243) <span class="badge badge--secondary">resotocore</span> Hash and flat need to be recomputed on update ([#602](https://github.com/someengineering/resoto/pull/602))
+- [`a8a1dd1f`](https://github.com/someengineering/resoto/commit/a8a1dd1f) <span class="badge badge--secondary">resotocore</span> Use debug logging instead of info ([#601](https://github.com/someengineering/resoto/pull/601))
+- [`a54e096c`](https://github.com/someengineering/resoto/commit/a54e096c) <span class="badge badge--secondary">docker</span> Fix runuser call ([#609](https://github.com/someengineering/resoto/pull/609))
+- [`ec39ba44`](https://github.com/someengineering/resoto/commit/ec39ba44) <span class="badge badge--secondary">docs</span> fix dead link in README ([#606](https://github.com/someengineering/resoto/pull/606))
+- [`21ac1bc6`](https://github.com/someengineering/resoto/commit/21ac1bc6) <span class="badge badge--secondary">docs</span> update outdated docs URI ([#598](https://github.com/someengineering/resoto/pull/598))

--- a/news/2022-02-02-v2.0.0.14.md
+++ b/news/2022-02-02-v2.0.0.14.md
@@ -1,6 +1,6 @@
-# 2.0.0a14
+# v2.0.0a14
 
-Highlight of this release: we now have a docker-compose file, so each component is started as separate process.
+Highlight of this release: we now have a sample [Docker Compose file](https://github.com/someengineering/resoto/blob/main/docker-compose.yaml) which utilizes the Docker images for each individual component!
 
 ## Features
 

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -1,0 +1,84 @@
+import csv
+import subprocess
+import sys
+from collections import namedtuple, defaultdict
+from typing import Dict, List
+
+import re
+
+Commit = namedtuple(
+    "Commit",
+    ["commit_hash", "author", "component", "group", "message", "pr", "timestamp"],
+)
+
+long_names = {"feat": "Features", "fix": "Fixes", "chore": "Chores"}
+rewrite_component = {"api-docs": "docs", "README": "docs"}
+
+
+def git_commits(from_tag: str, to_tag: str):
+    return subprocess.run(
+        [
+            "git",
+            "--no-pager",
+            "log",
+            "--pretty=format:%h§%aN§%s§%at",
+            f"{from_tag}..{to_tag}",
+        ],
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+
+
+def group_by(f, iterable):
+    v = defaultdict(list)
+    for item in iterable:
+        key = f(item)
+        v[key].append(item)
+    return v
+
+
+def parse_commit(row: list[str]) -> Commit:
+    commit_hash, author, msg, time = row
+    brackets = re.findall("\\[([^]]+)]", msg)
+    if len(brackets) == 2:
+        component, group = brackets
+    elif len(brackets) == 1:
+        component, group = brackets[0], "feat"
+    else:
+        component, group = "resoto", "feat"
+    message, pr = re.fullmatch("(?:\\[.+])?\s*(.*)\\(#(\d+)\\)", msg).groups()
+    return Commit(
+        commit_hash,
+        author,
+        rewrite_component.get(component, component),
+        group,
+        message,
+        pr,
+        time,
+    )
+
+
+def show_log(from_tag: str, to_tag: str):
+    grouped: Dict[str, List[Commit]] = group_by(
+        lambda c: c.group,
+        [
+            parse_commit(row)
+            for row in csv.reader(git_commits(from_tag, to_tag), delimiter="§")
+        ],
+    )
+
+    print(f"# {to_tag}\n")
+    for group, commits in grouped.items():
+        print(f"\n## {long_names.get(group, group)}\n")
+        for commit in commits:
+            print(
+                f"- [`{commit.commit_hash}`](https://github.com/someengineering/resoto/commit/{commit.commit_hash}) "
+                f'<span class="badge badge--secondary">{commit.component}</span> {commit.message}'
+                f"([#{commit.pr}](https://github.com/someengineering/resoto/pull/{commit.pr}))"
+            )
+
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} <from_tag> <to_tag>")
+else:
+    show_log(sys.argv[1], sys.argv[2])

--- a/tools/release_notes.py
+++ b/tools/release_notes.py
@@ -67,7 +67,7 @@ def show_log(from_tag: str, to_tag: str):
         ],
     )
 
-    print(f"# {to_tag}\n")
+    print(f"# v{to_tag}\n")
     for group, commits in grouped.items():
         print(f"\n## {long_names.get(group, group)}\n")
         for commit in commits:


### PR DESCRIPTION


# Description

<!-- Please describe the changes included in this PR here. -->

The script can be used to generate release notes.
It still is not able to mark highlights of a release, but it simplifies the tedious part.

Usage (cwd in the repository, since it uses `git log`):
```
python release_notes.py <from_tag> <to_tag>
```

The file here has been generated with:
```
python release_notes.py 2.0.0a13 2.0.0a14
```

# To-Dos

<!-- Before submitting this PR, please lint and build your changes locally. -->
<!-- Add an 'x' between the brackets to mark each checkbox as checked. -->

- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Issues Fixed

<!-- If this PR will fix/resolve an open issue on the repository, please reference it below. -->
<!-- Otherwise, please delete this section. -->

- Fixes #XXXX

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
