### PR TITLE
[TEST ONLY] feat: v2.0.0a15 release notes

### DIFF
--- a/news/2022-02-03-v2.0.0a15.md
+++ b/news/2022-02-03-v2.0.0a15.md
@@ -1,0 +1,10 @@
+# v2.0.0a15
+
+## Fixes
+
+- [`1d62780`](https://github.com/someengineering/resoto/commit/1d62780) <span class="badge badge--secondary">resotoworker</span> Use `/ancestors` during cleanup ([#617](https://github.com/someengineering/resoto/pull/617))
+- [`708202f`](https://github.com/someengineering/resoto/commit/708202f) <span class="badge badge--secondary">resotocore</span> Silence apscheduler logs ([#615](https://github.com/someengineering/resoto/pull/615))
+
+## Features
+
+- [`4c04f41`](https://github.com/someengineering/resoto/commit/4c04f41) <span class="badge badge--secondary">resoto</span> Bump 2.0.0a15 ([#612](https://github.com/someengineering/resoto/pull/612))


### PR DESCRIPTION
Adds automatically generated release notes for [v2.0.0a15](https://github.com/someengineering/resoto/releases/tag/2.0.0a15).