### PR TITLE
fix(docs): replace instances of 'query' with 'search'

### DIFF
--- a/blog/2022/02-04-resoto-search-101/index.md
+++ b/blog/2022/02-04-resoto-search-101/index.md
@@ -18,12 +18,12 @@ We created Resoto to allow the user to effortlessly [search resources](/docs/con
 
 Graph data is not relational, so SQL was not a good fit. And existing graph query languages like [Cypher](https://neo4j.com/developer/cypher), [Gremlin](https://tinkerpop.apache.org/gremlin.html), or [GSQL](https://tigergraph.com/gsql) have steep learning curves and are unnecessarily complex for this use case.
 
-And so, we developed our own search syntax tailored specifically to Resoto. The [Resoto Shell](/docs/concepts/components/shell) allows you to interact with your Resoto installation. In particular, it provides a [`query`](/docs/reference/cli/query) command.
+And so, we developed our own search syntax tailored specifically to Resoto. The [Resoto Shell](/docs/concepts/components/shell) allows you to interact with your Resoto installation. In particular, it provides a [`search`](/docs/reference/cli/search) command.
 
 Let's try searching for all available EC2 instances. `is()` will match a specific or abstract type in a polymorphic fashion, checking all types and subtypes of the provided type. The `instance_cores` filter will limit results to only those instances with more than two cores. The query will automagically search your entire infrastructure, regardless of account or region!
 
 ```bash
-> query is(aws_ec2_instance) and instance_cores > 2
+> search is(aws_ec2_instance) and instance_cores > 2
 // highlight-start
 id=i-a..., name=crmsec, age=2y2M, account=dev, region=us-east-1
 id=i-0..., name=airgap, age=2M, account=staging, region=eu-central-1
@@ -34,7 +34,7 @@ id=i-0..., name=flixer, age=1M3w, account=sales, region=us-west-2
 The query found three instances in three accounts and three regions. The default output is a condensed list view, but it is also possible to get all collected properties of any resource using the `dump` command:
 
 ```bash
-> query is(aws_ec2_instance) and instance_cores > 2 limit 1 | dump
+> search is(aws_ec2_instance) and instance_cores > 2 limit 1 | dump
 // highlight-start
 reported:
   kind: aws_ec2_instance
@@ -55,7 +55,7 @@ reported:
 Let us see how many EC2 instances we have grouped by `instance_type` using the `count` command:
 
 ```bash
-> query is(aws_ec2_instance) and instance_cores > 2 | count instance_type
+> search is(aws_ec2_instance) and instance_cores > 2 | count instance_type
 // highlight-start
 t3.2xlarge: 1
 m5.4xlarge: 15
@@ -73,7 +73,7 @@ When Resoto collects data on your cloud infrastructure, it creates an edge betwe
 ![Graph Structure](./img/graph_structure.svg)
 
 ```bash
-> query is(aws_ec2_instance) and instance_cores > 2 --> is(aws_elb)
+> search is(aws_ec2_instance) and instance_cores > 2 --> is(aws_elb)
 // highlight-start
 name=a5..., age=1y1M, account=sales, region=eu-central-1
 name=a3..., age=6M2w, account=staging, region=us-west-2
@@ -85,7 +85,7 @@ The `-->` arrow will take all matching EC2 instances and walk the graph "outboun
 It is also possible to reverse the last query to output all EC2 instances behind an ELB:
 
 ```bash
-> query is(aws_elb) <-- is(aws_ec2_instance) and instance_cores > 2
+> search is(aws_elb) <-- is(aws_ec2_instance) and instance_cores > 2
 // highlight-start
 id=i-0..., name=airgap, age=2M, account=staging, region=eu-central-1
 id=i-0..., name=flixer, age=1M3w, account=sales, region=us-west-2

--- a/blog/2022/03-03-aggregating-search-data/index.md
+++ b/blog/2022/03-03-aggregating-search-data/index.md
@@ -21,7 +21,7 @@ Resoto's search allows for resources to be selected using [filters](/docs/concep
 The simplest example of search aggregation in Resoto is the [`count` command](/docs/reference/cli/count), which enables you to count objects or the occurrences of a specific property. Let's say we are interested in the number of compute instances we maintain:
 
 ```bash
-> query is(instance) | count
+> search is(instance) | count
 // highlight-start
 total matched: 540
 total unmatched: 0
@@ -33,7 +33,7 @@ Compute instances are of [kind](/docs/concepts/graph/node#kind) `instance` regar
 The `count` command also allows specifying a grouping value. The following search would return counts by `instance_status`:
 
 ```bash
-> query is(instance) | count instance_status
+> search is(instance) | count instance_status
 // highlight-start
 stopped: 48
 terminated: 151
@@ -46,7 +46,7 @@ total unmatched: 0
 While [`count`](/docs/reference/cli/count) is often sufficient, the [`aggregate` command](/docs/reference/cli/aggregate) is required for more advanced use cases. For example, we could get CPU core and memory data using [`aggregate`](/docs/reference/cli/aggregate):
 
 ```bash
-> query is(instance) | aggregate
+> search is(instance) | aggregate
   sum(instance_cores) as sum_of_cores,
   max(instance_cores) as max_cores,
   sum(instance_memory) as sum_of_memory,
@@ -64,7 +64,7 @@ In this example, we have 3441 cores in total and each instance has a maximum of 
 We can further analyze this aggregated data using grouping variables, which we have already seen in an above example of the [`count` command](/docs/reference/cli/count). Let's try aggregating the available memory by instance status:
 
 ```bash
-> query is(instance) | aggregate
+> search is(instance) | aggregate
    instance_status as status:
    sum(instance_memory) as memory
 // highlight-start
@@ -95,7 +95,7 @@ Wouldn't it be great if we could aggregate over not only the data of a single no
 The above diagram illustrates the relationship between compute instances. AWS resources are attached to a region, while GCP resources are associated with a zone. Each instance also has a `instance_type` predecessor node. To access properties of ancestor nodes of a given kind, we can use the following notation:
 
 ```bash
-> query is(instance) | aggregate
+> search is(instance) | aggregate
   sum(/ancestors.instance_type.reported.ondemand_cost) as cost
 cost: 155.73
 ```
@@ -107,7 +107,7 @@ The path `/ancestors.instance_type.reported.ondemand_cost` can be translated as 
 It is possible to walk the graph inbound with `ancestors`, and outbound using `descendants`. You can apply this syntax anywhere a property path is defined in a search. Let's use this technique to find running instances aggregated by account and region:
 
 ```bash
-> query is(instance) and instance_status==running | aggregate
+> search is(instance) and instance_status==running | aggregate
   /ancestors.account.reported.name as account,
   /ancestors.region.reported.name as region:
   sum(instance_memory) as memory,

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 Welcome to the Resoto documentation!
 
 ```bash title="Hello World in Resoto 👋🌎"
-> query is(resource) | count
+> search is(resource) | count
 // highlight-start
 total matched: 459241
 total unmatched: 0

--- a/docs/concepts/automation/job.md
+++ b/docs/concepts/automation/job.md
@@ -2,16 +2,16 @@
 
 You can use the [Resoto Shell](../components/shell.md) to trigger commands in Resoto.
 
-Let's say you want to find all resources that have not been labeled with an owner tag. The following query would do the trick:
+Let's say you want to find all resources that have not been labeled with an owner tag. The following search would do the trick:
 
 ```bash
-> query is(resource) and tags.owner==null
+> search is(resource) and tags.owner==null
 ```
 
 Let's further assume you want to automatically set the owner tag for such resources. This can be achieved by using the `tag` command, which would update the tags of the elements to the defined value.
 
 ```bash
-> query is(resource) and tags.owner==null | tag update owner "John Doe"
+> search is(resource) and tags.owner==null | tag update owner "John Doe"
 ```
 
 While this is already an improvement, it will only update resources without tags at the moment. Resources that are created in the future and do not have an owner tag would need to be processed in the same way again.
@@ -21,18 +21,18 @@ Jobs allow you to take a defined CLI command and trigger it automatically either
 Let us now assume that we want to ensure there will be never resources without owner tag again. We can use the command we have written above and turn it into a job:
 
 ```bash
-> jobs add ensure-owner-tag --wait-for-event post_collect 'query is(resource) and tags.owner==null | tag update owner "John Doe"'
+> jobs add ensure-owner-tag --wait-for-event post_collect 'search is(resource) and tags.owner==null | tag update owner "John Doe"'
 // highlight-next-line
 Job ensure-owner-tag added.
 ```
 
-- The query and tag command is the same that we used before. To not conflict with the `jobs` command line, the job command line is wrapped in single quotes (if we would omit those, we would write: `jobs add ... | tag ...` which is not what we want).
-- `jobs add` is used to turn the command line into a job. A job is persisted in the database and will be available until it is deleted explicitly.
+- `search` and `tag` are the same commands that we used before. To not conflict with the `jobs` command, the `job` command is wrapped in single quotes (if we would omit those, we would write: `jobs add ... | tag ...` which is not what we want).
+- `jobs add` is used to turn the command into a job. A job is persisted in the database and will be available until it is deleted explicitly.
 - The job is triggered by the occurrence of the event `post_collect`. See ref:`workflow-collect_and_cleanup` where this event is emitted by the default workflow after all resources have been collected. Since this workflow itself is triggered every hour, this job will be called constantly and operate on fresh data.
 
 :::note
 
-The jobs are executed server-side and the resulting output is written to the log file.
+Jobs are executed server-side and their outputs are written to the log file.
 
 It probably does not make a lot of sense to turn commands into jobs that do not have any side effect (side effects would be sending a notification, triggering a REST endpoint, manipulating the resources directly, etc.), since you will only see the result in the log stream.
 
@@ -56,31 +56,35 @@ It probably does not make a lot of sense to turn commands into jobs that do not 
 
 The job functionality can be used to automate actions. Here is a list of possible topics that could be natural candidates for automation:
 
-- Encode a set of rules.
+- **Encode a set of rules.**
 
-  Define rules as queries in a way that all results returned by this query violate the rule.
+  Define rules as queries in a way that all results returned by this search violate the rule.
 
   The job would run after collect is finished (`post_collect`).
 
-  Ideally, the query will not find a single entry so it will not trigger any further functionality.
+  Ideally, the search will not find a single entry so it will not trigger any further functionality.
 
-  The query should be combined with the `notify` command (coming soon) or the `http` command to call into another system to handle such cases.
+  The search should be combined with the `notify` command (coming soon) or the `http` command to call into another system to handle such cases.
 
-- Gather or accumulate data.
+- **Gather or accumulate data.**
 
-  Resoto has advanced aggregation query capabilities. resotometrics is using it to derive and report metrics to [Prometheus](https://prometheus.io).
+  Resoto has advanced [search aggregation](../search/aggregation.md) capabilities. [Resoto Metrics](../components/metrics.md) uses aggregation to derive and report metrics to [Prometheus](https://prometheus.io).
 
   If additional data besides metrics are relevant to you, create a job that gathers and publishes the data.
 
-  You would use `query` aggregation and `http` to implement this functionality.
+  You would use [search aggregation](../search/aggregation.md) and [`http`](../../reference/cli/http.md) to implement this functionality.
 
-- Up to date diagrams.
+- **Generate up-to-date diagrams.**
 
   Did you know that Resoto can provide graph diagrams in dot format?
 
-  Try this in resotoshell (`resh`): `query --include-edges is(graph_root) -[0:2]-> | format --dot | write out.dot`.
+  Try this in [Resoto Shell (`resh`)](../components/shell.md):
 
-  This will query the graph from the root and traverse it 2 levels deep and will also emit all edges.
+  ```bash
+  > search --include-edges is(graph_root) -[0:2]-> | format --dot | write out.dot
+  ```
+
+  This will search the graph from the root and traverse it 2 levels deep and will also emit all edges.
 
   The resulting graph will be formatted in `Graphviz <https://graphviz.org>` dot format and written to file `out.dot`.
 
@@ -88,7 +92,7 @@ The job functionality can be used to automate actions. Here is a list of possibl
 
   You could automate the generation of diagrams and would always have up-to-date documentation.
 
-- Define resources for cleanup
+- **Define resources for cleanup.**
 
   Resoto allows you to define resources with an expiration via [custom tags](https://github.com/someengineering/resoto/tree/main/plugins/cleanup_expired#tag-format).
 
@@ -97,10 +101,10 @@ The job functionality can be used to automate actions. Here is a list of possibl
   Imagine you want to cleanup all compute instances in the load-testing account every Friday night, so they will not run over the weekend.
 
   ```bash
-  > jobs add mark-resources-for-cleanup --schedule '0 22 * * 5' --wait-for-event cleanup_plan 'query is(instance) and /ancestors.account.reported.name==load-testing | clean'
+  > jobs add mark-resources-for-cleanup --schedule '0 22 * * 5' --wait-for-event cleanup_plan 'search is(instance) and /ancestors.account.reported.name==load-testing | clean'
   ```
 
-- Enforce tags structure
+- **Enforce tag structure.**
 
   Almost all cloud providers offer the ability to annotate resources with tags.
 
@@ -108,7 +112,7 @@ The job functionality can be used to automate actions. Here is a list of possibl
 
   It is not an easy task to enforce valid tags, since there is usually nothing from the provider side to help with.
 
-  With Resoto it is easy to query all resource tags with a simple query.
+  With Resoto it is easy to search all resource tags with a simple search syntax.
 
   There is also the `tag` command which allows to update or delete tags.
 
@@ -116,6 +120,6 @@ The job functionality can be used to automate actions. Here is a list of possibl
 
   or you can use the `tag` command to directly fix the issue.
 
-- And much more…
+- **And much more…**
 
 This list should give inspiration for possible jobs that can be automated and is by no means complete. We are interested in your use case - so please create a PR and extend this list.

--- a/docs/concepts/components/core.md
+++ b/docs/concepts/components/core.md
@@ -11,23 +11,23 @@ Within Resoto Core, there are workflows consisting of steps that result in actio
 
 ## API
 
-The Resoto Core API is exposed at `http://<resoto-address>:8900/api-doc`. You can also access it at [`https://resoto.com/docs/reference/core-api`](pathname:///docs/reference/core-api).
+The [Resoto Core API](../../reference/api.md) is exposed at `http://<resoto-address>:8900/api-doc`. You can also access it at [`https://resoto.com/docs/reference/api`](../../reference/api.md).
 
-Resoto Core has two API endpoints to connect to for CLI purposes:
+Resoto Core has two [API](../../reference/api.md) endpoints to connect to for CLI purposes:
 
-1. `/cli/evaluate`
-2. `/cli/execute`
+1. [`/cli/evaluate`](../../reference/api.md#tag/cli/paths/~1cli~1evaluate/post)
+2. [`/cli/execute`](../../reference/api.md#tag/cli/paths/~1cli~1execute/post)
 
-The `cli/evaluate` functinality is used internally on every `/cli/execute` before the command executes.
+The [`/cli/evaluate`](../../reference/api.md#tag/cli/paths/~1cli~1evaluate/post) functinality is used internally on every [`/cli/execute`](../../reference/api.md#tag/cli/paths/~1cli~1execute/post) before the command executes.
 
-Below is a simulation of sending a [Resoto Shell](./shell.md) query to the CLI API.
+Below is a simulation of sending a [Resoto Shell](./shell.md) [search](../search/README.md) to the [API](../../reference/api.md).
 
-We will evaluate the query before executing it for demonstration. We also introduce this query with a typo to show the response if not successful.
+We will evaluate the search before executing it for demonstration. We also introduce a search with a typo to show the response if not successful.
 
 ### Evaluate
 
 ```bash title="Correct"
-> echo 'query is("resource") limit 1' | http :8900/cli/evaluate
+> echo 'search is("resource") limit 1' | http :8900/cli/evaluate
 // highlight-start
 HTTP/1.1 200 OK
 Content-Length: 47
@@ -44,7 +44,7 @@ Server: Python/3.9 aiohttp/3.7.4.post0
 ```
 
 ```bash title="Typo"
-> echo 'graph=resoto query is("resource") limit1' | http :8900/cli/evaluate
+> echo 'graph=resoto search is("resource") limit1' | http :8900/cli/evaluate
 // highlight-start
 HTTP/1.1 400 Bad Request
 Content-Length: 151
@@ -60,7 +60,7 @@ Message: expected one of '!=', '!~', '<', '<=', '=', '==', '=~', '>', '>=', '[A-
 ## Execute
 
 ```bash title="Correct"
-> echo 'graph=resoto query is("resource") limit 1' | http :8900/cli/execute
+> echo 'graph=resoto search is("resource") limit 1' | http :8900/cli/execute
 // highlight-start
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -94,7 +94,7 @@ Transfer-Encoding: chunked
 ```
 
 ```bash title="Typo"
-> echo 'graph=resoto query is("resource") limit1' | http :8900/cli/execute
+> echo 'graph=resoto search is("resource") limit1' | http :8900/cli/execute
 // highlight-start
 HTTP/1.1 400 Bad Request
 Content-Length: 151
@@ -109,4 +109,4 @@ Message: expected one of '!=', '!~', '<', '<=', '=', '==', '=~', '>', '>=', '[A-
 
 # More API Endpoints
 
-Resoto Core is the central hub for everything Resoto does. You can explore additional API endpoints at `http://<resoto-address>:8900/` or [`https://resoto.com/docs/reference/core-api`](pathname:///docs/reference/core-api).
+Resoto Core is the central hub for everything Resoto does. You can explore additional API endpoints at `http://<resoto-address>:8900/api-doc` or [`https://resoto.com/docs/reference/api`](../../reference/api.md).

--- a/docs/concepts/graph/README.md
+++ b/docs/concepts/graph/README.md
@@ -11,10 +11,10 @@ Resoto maintains its collected data in a graph database. This graph can be acces
 
 :::tip
 
-Performing a search in the [Resoto Shell](../components/shell.md) [command-line interface (CLI)](../../reference/cli/README.md) is done using the [`query`](../../reference/cli/query.md) command.
+Performing a search in the [Resoto Shell](../components/shell.md) [command-line interface (CLI)](../../reference/cli/README.md) is done using the [`search`](../../reference/cli/search.md) command.
 
 ```bash
-> query is(aws_account)
+> search is(aws_account)
 ```
 
 :::

--- a/docs/concepts/search/aggregation.md
+++ b/docs/concepts/search/aggregation.md
@@ -10,7 +10,7 @@ There are several situations where specific data is not too relevant but needs l
 For example, the following search will select and count compute instances that are older than 3 years:
 
 ```bash
-> query is(instance) and age > 3y | count
+> search is(instance) and age > 3y | count
 // highlight-start
 total matched: 21
 total unmatched: 0
@@ -34,12 +34,12 @@ Each grouping function can have an `as <name>` clause to give the function resul
 
 Example: `min(memory)`, `sum(1) as count`, `avg(instance_cores) as average_cores`.
 
-The [`aggregate` command](../../reference/cli/aggregate.md) tells Resoto to aggregate the query results based on the defined criteria. Each result of the query is then passed to the defined aggregation function(s).
+The [`aggregate` command](../../reference/cli/aggregate.md) tells Resoto to aggregate the search results based on the defined criteria. Each result of the search is then passed to the defined aggregation function(s).
 
 The above example using the [`count`](../../reference/cli/count.md) could also be rewritten with `aggregate` like so:
 
 ```bash
-> query is(instance) and age > 3y | aggregate sum(1) as count
+> search is(instance) and age > 3y | aggregate sum(1) as count
 // highlight-start
 count: 21
 // highlight-end
@@ -50,7 +50,7 @@ Every element is counted as `1`, so `sum(1)` is the number of elements.
 It is also possible to define multiple aggregation functions. Let's count both instances and cores:
 
 ```bash
-> query is(instance) and age > 3y | aggregate
+> search is(instance) and age > 3y | aggregate
   sum(1) as count,
   sum(instance_cores) as cores
 // highlight-start
@@ -62,7 +62,7 @@ cores: 66
 We could even compute the average, minimum, and maximum number of available cores:
 
 ```bash
-> query is(instance) and age > 3y | aggregate
+> search is(instance) and age > 3y | aggregate
   sum(1) as count,
   sum(instance_cores) as cores,
   min(instance_cores) as min_cores,
@@ -86,7 +86,7 @@ A group is defined using a property path. The value of this path is looked up in
 For example, instances can be grouped by status:
 
 ```bash
-> query is(instance) and age > 3y | aggregate instance_status: sum(1) as count
+> search is(instance) and age > 3y | aggregate instance_status: sum(1) as count
 // highlight-start
 group:
   instance_status: running
@@ -107,7 +107,7 @@ Grouping variable can be named using `as`. By default, the last part of the path
 Additional aggregation functions also get applied on each group:
 
 ```bash
-> query is(instance) and age > 3y | aggregate instance_status as status:
+> search is(instance) and age > 3y | aggregate instance_status as status:
   sum(1) as count,
   sum(instance_cores) as cores,
   min(instance_cores) as min_cores,
@@ -143,7 +143,7 @@ avg_cores: 2.2
 Groups can also be defined using multiple grouping variables:
 
 ```bash
-> query is(instance) and age > 3y | aggregate
+> search is(instance) and age > 3y | aggregate
   instance_status as status, instance_type as type:
   sum(1) as count,
   sum(instance_cores) as cores

--- a/docs/concepts/search/examples.md
+++ b/docs/concepts/search/examples.md
@@ -7,42 +7,42 @@ sidebar_label: Examples
 
 The following are some common queries for Resoto, organized by [kind](../graph/node.md#kind).
 
-Do you need help writing a query? Join us on [Discord](https://discord.gg/someengineering) and we'll do our best to help!
+Do you need help writing search syntax? Join us on [Discord](https://discord.gg/someengineering) and we'll do our best to help!
 
-Have you written a query others may find useful? Contributions to this page are welcome!
+Have you written a search others may find useful? [Contributions to this page are welcome!](https://github.com/someengineering/resoto.com/edit/main/docs/concepts/search/examples.md)
 
 :::note
 
-All queries listed here are safe to use, as they will _NOT_ modify your resources.
+All queries listed here are safe to try out, as they will _NOT_ modify your resources.
 
 :::
 
 ## `aws_alb`
 
 ```bash title="Orphaned Load Balancers that have no active backend"
-> query is(aws_alb) and age > 7d and backends==[] with(empty, <-- is(aws_alb_target_group) and target_type = instance and age > 7d with(empty, <-- is(aws_ec2_instance) and instance_status != terminated)) <-[0:1]- is(aws_alb_target_group) or is(aws_alb)
+> search is(aws_alb) and age > 7d and backends==[] with(empty, <-- is(aws_alb_target_group) and target_type = instance and age > 7d with(empty, <-- is(aws_ec2_instance) and instance_status != terminated)) <-[0:1]- is(aws_alb_target_group) or is(aws_alb)
 ```
 
 ## `aws_iam_access_key`
 
 ```bash title="Ensure there is only one active access key available for any single IAM user"
-> query is(access_key) access_key_status = "Active" | aggregate user_name as user : sum(1) as number_of_keys
+> search is(access_key) access_key_status = "Active" | aggregate user_name as user : sum(1) as number_of_keys
 ```
 
 ## `certificate`
 
 ```bash title="Find expired ssl certificates currently in use"
-> query is(certificate) and expires < @NOW@ <--
+> search is(certificate) and expires < @NOW@ <--
 ```
 
 ## `quota`
 
 ```bash title="Find current quota consumption to prevent service interruptions"
-> query is(quota) and usage > 0
+> search is(quota) and usage > 0
 ```
 
 ## `volume`
 
 ```bash title="Find unused AWS volumes older than 30 days with no IO in the past 7 days"
-> query is(aws_ec2_volume) and age > 30d and last_access > 7d and last_update > 7d and volume_status = available
+> search is(aws_ec2_volume) and age > 30d and last_access > 7d and last_update > 7d and volume_status = available
 ```

--- a/docs/concepts/search/filters.md
+++ b/docs/concepts/search/filters.md
@@ -7,7 +7,7 @@ sidebar_label: Filters
 
 ## Selecting Nodes by [Kind](../graph/node.md#kind)
 
-In order to select nodes by a specific type, the query language supports the `is(<kind>)` function. The term `is(instance)` would select the EC2 instance above, but also all other instances, e.g. Google Cloud instances, while the term `is(aws_ec2_instance)` would select only EC2 instances from AWS.
+In order to select nodes by a specific type, the search syntax supports the `is(<kind>)` function. The term `is(instance)` would select the EC2 instance above, but also all other instances, e.g. Google Cloud instances, while the term `is(aws_ec2_instance)` would select only EC2 instances from AWS.
 
 You can get a list of all available kinds via the `kind` CLI command.
 
@@ -157,23 +157,23 @@ It is possible to negate a simple predicate or more complex term with `not`.
 :::tip Examples
 
 ```bash title="Select nodes where reported.name is either sunrise or sunset"
-> query name in [sunset, sunrise]
+> search name in [sunset, sunrise]
 ```
 
 ```bash title="Select instance nodes where reported.name is sunrise"
-> query is(instance) and name==sunrise
+> search is(instance) and name==sunrise
 ```
 
 ```bash title="Select aws_ec2_instance nodes of specific type or more than 2 cores"
-> query is(aws_ec2_instance) and (instance_type=="m5a.large" or instance_cores>2)
+> search is(aws_ec2_instance) and (instance_type=="m5a.large" or instance_cores>2)
 ```
 
 ```bash title="Select instance nodes in an account which name includes the term "engineering"
-> query is(instance) and /ancestors.account.reported.name=~engineering
+> search is(instance) and /ancestors.account.reported.name=~engineering
 ```
 
 ```bash title="Select all instance nodes wich are not in the engineering account"
-> query is(instance) and not /ancestors.account.reported.name==engineering
+> search is(instance) and not /ancestors.account.reported.name==engineering
 ```
 
 :::

--- a/docs/concepts/search/merging-nodes.md
+++ b/docs/concepts/search/merging-nodes.md
@@ -5,7 +5,7 @@ sidebar_label: Merging Nodes
 
 # Merging Nodes in Search
 
-While it is possible to query and retrieve a filtered part of the graph, it is sometimes helpful to retrieve structural graph data as part of the node.
+While it is possible to search and retrieve a filtered part of the graph, it is sometimes helpful to retrieve structural graph data as part of the node.
 
 This approach merges multiple nodes in a graph into one node. This combined node can simplify processing the node.
 
@@ -19,10 +19,10 @@ Most cloud resources are maintained in an account. Accounts are modeled as [node
 
 Resources reference the region node, while the region node references the account node. In order to retrieve the account, the graph has to be traversed inbound from the resource node until the account node is found. While this is possible, it might be more convenient to get the account information as part of the node!
 
-In this example, we query nodes of kind `volume`. For every element that is returned, a nested search is executed, which will traverse the graph inbound until it finds a node of kind `account`.
+In this example, we search for nodes of kind `volume`. For every element that is returned, a nested search is executed, which will traverse the graph inbound until it finds a node of kind `account`.
 
 ```bash
-> query is(volume) { account: <-[0:]- is(account) } limit 1 | dump
+> search is(volume) { account: <-[0:]- is(account) } limit 1 | dump
 // highlight-start
 reported:
     .
@@ -44,7 +44,7 @@ You will notice that the account, cloud, region, and zone are displayed for ever
 
 :::
 
-A nested search is a complete, standalone query and can use the features of any other query.
+A nested search is a complete, standalone query and can use the features of any other search.
 
 The result of a nested search is merged with the original node under the given merge name.
 
@@ -54,10 +54,10 @@ If the expected result of the nested search is a list, than the merge name has t
 
 :::tip Example
 
-The following query will traverse inbound on every element and collect all predecessors under the name `predecessors`). Please note the square brackets in the name `predecessors[]` - which will tell the search engine to return all predecessors, not only the first one. As a result the node is returned with a new property, which contains the list of all predecessors.
+The following search will traverse inbound on every element and collect all predecessors under the name `predecessors`). Please note the square brackets in the name `predecessors[]` - which will tell the search engine to return all predecessors, not only the first one. As a result the node is returned with a new property, which contains the list of all predecessors.
 
 ```bash
-> query is(volume) { predecessors[]: <-- all } limit 1 | dump
+> search is(volume) { predecessors[]: <-- all } limit 1 | dump
 // highlight-start
 reported:
     .
@@ -74,14 +74,14 @@ predecessors:
 
 :::
 
-It is also possible to define multiple merge queries in one query statement.
+It is also possible to define multiple merge queries in one `search` statement.
 
 :::tip Example
 
 As a result every node that is returned has two additional properties: `account` holds the complete data of the account node, as well `region`, which contains the related region node.
 
 ```bash
-> query is(volume) { account: <-[0:]- is(account), region: <-[0:]- is(region) } limit 1 | dump
+> search is(volume) { account: <-[0:]- is(account), region: <-[0:]- is(region) } limit 1 | dump
 // highlight-start
 reported:
     .
@@ -104,12 +104,12 @@ You will notice that the account, cloud, region, and zone are displayed for ever
 A nested search can even be defined using nested searches:
 
 ```bash
-> query = <pre_filter> { <merge_name_1>: <query>, .., <merge_name_n>: <query> } <post_filter>
+> search = <pre_filter> { <merge_name_1>: <query>, .., <merge_name_n>: <query> } <post_filter>
 ```
 
 :::note
 
-Be aware that a nested search is executed for every node of the original query and might be expensive and time intensive to compute.
+Be aware that a nested search is executed for every node of the original search and might be expensive and time intensive to compute.
 
 :::
 
@@ -124,7 +124,7 @@ Resoto provides the `ancestors` and `descendants` section as part of every resou
 If we want to filter resources in a specific account by their identifiers, we can simply add a filter expression:
 
 ```bash
-> query is(volume) and /ancestors/account/reported/id==dev limit 1
+> search is(volume) and /ancestors/account/reported/id==dev limit 1
 ```
 
 Let's break down the filter expression:
@@ -148,7 +148,7 @@ It is possible to access every property of every parent or child resource in thi
 This is the nested search that is automatically created for the above example:
 
 ```bash
-> query is(volume) {/ancestors.account: <-[1:]- is(account)} /ancestors.account.reported.id==dev
+> search is(volume) {/ancestors.account: <-[1:]- is(account)} /ancestors.account.reported.id==dev
 ```
 
 ### Cloud, Account, Region, and Zone

--- a/docs/concepts/search/traversals.md
+++ b/docs/concepts/search/traversals.md
@@ -16,7 +16,7 @@ sidebar_label: Traversals
 :::tip Example
 
 ```bash title="Select AWS accounts and traverse the graph outbound"
-> query is(aws_account) -->
+> search is(aws_account) -->
 ```
 
 This query would return a list of all matching regions.
@@ -32,7 +32,7 @@ This query would return a list of all matching regions.
 :::tip Example
 
 ```bash title="Select AWS EC2 instances, traverse the graph inbound, and filter to only return the aws_regions"
-> query is(aws_ec2_instance) <-- is(aws_region)
+> search is(aws_ec2_instance) <-- is(aws_region)
 ```
 
 ![Inbound Traversal Example Query Diagram](./img/graph_query_inbound_example.png)
@@ -46,7 +46,7 @@ This query would return a list of all matching regions.
 :::tip Example
 
 ```bash title="Return all resources "under" an aws_region together with the matching aws_region"
-> query is(aws_region) -[0:1]->`
+> search is(aws_region) -[0:1]->`
 ```
 
 ![Example Query Diagram](./img/graph_query_01.png)
@@ -56,7 +56,7 @@ This query would return a list of all matching regions.
 :::tip Example
 
 ```bash title="Return all aws_regions with name global, together with all accounts"
-> query is(aws_region) and name==global <-[0:1]-
+> search is(aws_region) and name==global <-[0:1]-
 ```
 
 :::
@@ -74,7 +74,7 @@ This query would return a list of all matching regions.
 The following query answers the question, "Which instance profile is used for ec2 instances connected to an alb target group?"
 
 ```bash title="Select aws_alb_target_groups, traverse 2 levels inbound, and filter for aws_iam_instance_profiles"
-> query is(aws_alb_target_groups) <-[2:2]- is(aws_iam_instance_profile)
+> search is(aws_alb_target_groups) <-[2:2]- is(aws_iam_instance_profile)
 ```
 
 :::
@@ -86,7 +86,7 @@ The following query answers the question, "Which instance profile is used for ec
 :::tip Example
 
 ```bash
-> query is(aws_account) and name==sunshine -[0:]->
+> search is(aws_account) and name==sunshine -[0:]->
 ```
 
 This query will select the aws account with name `sunshine` and then select all nodes outbound to this node. This will select everything Resoto knows about nodes in this account.
@@ -100,7 +100,7 @@ This query will select the aws account with name `sunshine` and then select all 
 :::tip Example
 
 ```bash title="Select nodes with the name sunset connected on any depth to the AWS account"
-> query name="sunset" and is(aws_account) <-[0:]->
+> search name="sunset" and is(aws_account) <-[0:]->
 ```
 
 :::
@@ -155,11 +155,11 @@ is(volume) and name==foo -default,delete->
 There is special syntax if you want to traverse the graph in both directions using different edge types for every direction:
 
 ```bash title="Pick one volume, then traverse delete dependencies both inbound and outbound"
-> query is(volume) limit 1 <-delete[1:1]->
+> search is(volume) limit 1 <-delete[1:1]->
 ```
 
 ```bash title="Pick one volume, then traverse inbound using delete dependencies and outbound using both delete and default dependencies"
-> query is(volume) limit 1 <-delete[1:1]default,delete->
+> search is(volume) limit 1 <-delete[1:1]default,delete->
 ```
 
 ## Abbreviations
@@ -175,12 +175,12 @@ There are abbreviations for commonly used traversal selectors:
 
 :::tip Examples
 
-| Abbreviated                    | Unabbreviated                    |
-| ------------------------------ | -------------------------------- |
-| `query is(aws_account) -->`    | `query is(aws_account) -[1:1]->` |
-| `query is(aws_region) <-->`    | `query is(aws_region) <-[1:1]->` |
-| `<-[x]-`                       | `<-[x:x]-`                       |
-| `query is(aws_region) <-[3]->` | `query is(aws_region) <-[3:3]->` |
+| Abbreviated                     | Unabbreviated                     |
+| ------------------------------- | --------------------------------- |
+| `search is(aws_account) -->`    | `search is(aws_account) -[1:1]->` |
+| `search is(aws_region) <-->`    | `search is(aws_region) <-[1:1]->` |
+| `<-[x]-`                        | `<-[x:x]-`                        |
+| `search is(aws_region) <-[3]->` | `search is(aws_region) <-[3:3]->` |
 
 :::
 

--- a/docs/concepts/search/with-clause.md
+++ b/docs/concepts/search/with-clause.md
@@ -21,7 +21,7 @@ graph LR;
 Let's say we want to select all ALB target groups where there is no EC2 instance using the ALB:
 
 ```bash
-> query is(aws_alb_target_group) with (empty, --> is(aws_ec2_instance))
+> search is(aws_alb_target_group) with (empty, --> is(aws_ec2_instance))
 ```
 
 1. The `is(aws_alb_target_group)` part selects all aws_alb_target_groups.

--- a/docs/getting-started/performing-searches.md
+++ b/docs/getting-started/performing-searches.md
@@ -7,43 +7,43 @@ pagination_prev: getting-started/README
 Resoto's search syntax is quite powerful and has many features. Once Resoto has finished its first collect run, we suggest trying these example queries:
 
 ```bash title="Get number of collected resources"
-> query is(resource) | count
+> search is(resource) | count
 ```
 
 ```bash title="Get list of all the compute instances"
-> query is(instance)
+> search is(instance)
 ```
 
 ```bash title="Get CSV-style list of name, type, cores, and memory for each account"
-> query is(instance) | format {/ancestors.account.reported.name},{name},{instance_type},{instance_cores},{instance_memory}
+> search is(instance) | format {/ancestors.account.reported.name},{name},{instance_type},{instance_cores},{instance_memory}
 ```
 
 ```bash title="Write formatted list of instance IDs and their creation times to outfile.txt"
-> query is(instance) | format {id},{ctime} | write outfile.txt
+> search is(instance) | format {id},{ctime} | write outfile.txt
 ```
 
 ```bash title="Get list of all compute instances with more than two CPU cores"
-> query is(instance) and instance_cores > 2
+> search is(instance) and instance_cores > 2
 ```
 
 ```bash title="Get all AWS EC2 instances and display the metadata of the last instance"
-> query is(aws_ec2_instance) | tail -1 | dump
+> search is(aws_ec2_instance) | tail -1 | dump
 ```
 
 ```bash title="Get list of EBS volumes that are not in use, larger than 10GB, older than 30 days, and with no I/O during the past 7 days"
-> query is(aws_ec2_volume) and volume_status = available and volume_size > 10 and age > 30d and last_access > 7d
+> search is(aws_ec2_volume) and volume_status = available and volume_size > 10 and age > 30d and last_access > 7d
 ```
 
 ```bash title="Aggregate the number of EC2 instances by account ID"
-> query aggregate(/ancestors.account.reported.id as account_id: sum(1) as instance_count): is(aws_ec2_instance)
+> search aggregate(/ancestors.account.reported.id as account_id: sum(1) as instance_count): is(aws_ec2_instance)
 ```
 
 ```bash title="Aggregate RAM usage (bytes) data grouped by cloud, account, region, and instance type"
-> query aggregate(/ancestors.cloud.reported.name as cloud, /ancestors.account.reported.name as account, /ancestors.region.reported.name as region, instance_type as type: sum(instance_memory * 1024 * 1024 * 1024) as memory_bytes): is(instance) and instance_status == running
+> search aggregate(/ancestors.cloud.reported.name as cloud, /ancestors.account.reported.name as account, /ancestors.region.reported.name as region, instance_type as type: sum(instance_memory * 1024 * 1024 * 1024) as memory_bytes): is(instance) and instance_status == running
 ```
 
 ```bash title="Aggregate hourly instance cost grouped by cloud, account, region, and type from the cost information associated with the instance_type higher up in the graph"
-> query aggregate(/ancestors.cloud.reported.name as cloud, /ancestors.account.reported.name as account, /ancestors.region.reported.name as region, instance_type as type: sum(/ancestors.instance_type.reported.ondemand_cost) as instances_hourly_cost_estimate): is(instance) and instance_status == running
+> search aggregate(/ancestors.cloud.reported.name as cloud, /ancestors.account.reported.name as account, /ancestors.region.reported.name as region, instance_type as type: sum(/ancestors.instance_type.reported.ondemand_cost) as instances_hourly_cost_estimate): is(instance) and instance_status == running
 ```
 
 The above examples only highlight some of what is possible with Resoto's search syntax. For more in-depth explanations and additional examples, please refer to the [search documentation](../concepts/search/README.md).

--- a/docs/getting-started/pruning-resources.md
+++ b/docs/getting-started/pruning-resources.md
@@ -4,7 +4,7 @@
 
 Please act with caution when selecting and filtering resources for cleanup.
 
-If you run `query is(aws_ec2_volume) | clean`, it marks _all_ `aws_ec2_volume` resources in your cloud for deletion.
+If you run `search is(aws_ec2_volume) | clean`, it marks _all_ `aws_ec2_volume` resources in your cloud for deletion.
 
 :::
 
@@ -16,7 +16,7 @@ You can provide `--cleanup-dry-run` at [`resotoworker`](../concepts/components/w
 
 When doing a resource cleanup selection for the first time, it is good practice to confirm the list of selected resources for plausibility using something like `desired clean = true | count`.
 
-To quickly undo marking all `aws_ec2_volumes` for cleanup, use `query is(aws_ec2_volume) | set_desired clean=false`.
+To quickly undo marking all `aws_ec2_volumes` for cleanup, use `search is(aws_ec2_volume) | set_desired clean=false`.
 
 To remove clean markers from all resources, you can use `desired clean=true | set_desired clean=false`.
 
@@ -31,7 +31,7 @@ This will add `desired.clean = true` to all matched ressources.
 Optionally, you can provide a reason for marking the matched ressources for the next cleanup run:
 
 ```bash title="Mark all unused EBS volume older than 30 days that had no IO in the past 7d"
-> query is(volume) and ctime < -30d and atime < -7d and mtime < -7d and volume_status = available | clean "older than 30d with more then 7d of not beeing used"
+> search is(volume) and ctime < -30d and atime < -7d and mtime < -7d and volume_status = available | clean "older than 30d with more then 7d of not beeing used"
 ```
 
 ## Prune Resources Marked for Deletion

--- a/docs/reference/cli/README.md
+++ b/docs/reference/cli/README.md
@@ -33,7 +33,7 @@ You can pipe commands using `|` and chain multiple commands using `;`.
 | [`list`](./list.md)                 | Transform incoming objects as string with defined properties.                       |
 | [`predecessors`](./predecessors.md) | Select all predecessors of this node in the graph.                                  |
 | `protect`                           | Mark all incoming database objects as protected.                                    |
-| [`query`](./query.md)               | Query the graph.                                                                    |
+| [`search`](./search.md)             | Search the graph.                                                                   |
 | `set_desired`                       | Allows to set arbitrary properties as desired for all incoming database objects.    |
 | `set_metadata`                      | Allows to set arbitrary properties as metadata for all incoming database objects.   |
 | `sleep`                             | Suspend execution for an interval of time.                                          |
@@ -50,7 +50,8 @@ You can pipe commands using `|` and chain multiple commands using `;`.
 
 | Alias            | Command      | Description                              |
 | ---------------- | ------------ | ---------------------------------------- |
-| `match`          | `query`      | Query the graph.                         |
+| `match`          | `search`     | Search the graph.                        |
+| `query`          | `search`     | Search the graph.                        |
 | `start_workflow` | `start_task` | Start a task with the given name.        |
 | `https`          | `http`       | Perform HTTP request with incoming data. |
 

--- a/docs/reference/cli/aggregate.md
+++ b/docs/reference/cli/aggregate.md
@@ -37,7 +37,7 @@ Each grouping function can have an `as <name>` clause to give the function resul
 ## Examples
 
 ```bash title="Count volumes in the system, grouped by kind"
-> query is(volume) | aggregate kind as kind: sum(1) as count
+> search is(volume) | aggregate kind as kind: sum(1) as count
 group:
   kind: aws_ec2_volume
 count: 1799
@@ -48,7 +48,7 @@ count: 1100
 ```
 
 ```bash title="Count volumes and compute total volume size, grouped by kind"
-> query is(volume) | aggregate kind: sum(volume_size) as summed, sum(1) as count
+> search is(volume) | aggregate kind: sum(volume_size) as summed, sum(1) as count
 group:
   reported.kind: aws_ec2_volume
 summed: 130903
@@ -61,11 +61,11 @@ count: 1100
 ```
 
 ```bash title="Count volumes and compute total volume size"
-> query is(volume) | aggregate sum(volume_size) as summed, sum(1) as count
+> search is(volume) | aggregate sum(volume_size) as summed, sum(1) as count
 summed: 154833
 count: 2899
 ```
 
 ## See Also
 
-- [`query`](./query.md)
+- [`search`](./search.md)

--- a/docs/reference/cli/ancestors.md
+++ b/docs/reference/cli/ancestors.md
@@ -25,15 +25,15 @@ ancestors [--with-origin] <edge_type>
 ## Examples
 
 ```bash title="Equivalent to query is(aws_region) <-[1:]-"
-> query is(aws_region) | ancestors
+> search is(aws_region) | ancestors
 ```
 
 ```bash title="Equivalent to query is(aws_region) <-[0:]-"
-> query is(aws_region) | ancestors --with-origin
+> search is(aws_region) | ancestors --with-origin
 ```
 
 ```bash
-> query is(volume_type) limit 1 | ancestors
+> search is(volume_type) limit 1 | ancestors
 // highlight-start
 kind=gcp_service_sku, id=D2, name=Storage PD Capacity, age=5d8h, cloud=gcp, account=sre
 kind=gcp_zone, id=2, name=us-central1-a, age=52yr1mo, cloud=gcp, account=sre, region=us-central1, zone=us-central1-a

--- a/docs/reference/cli/clean.md
+++ b/docs/reference/cli/clean.md
@@ -21,7 +21,7 @@ clean <reason>
 ## Examples
 
 ```bash title="Mark query results for cleaning"
-> query isinstance("ec2") and atime<"-2d" | clean
+> search isinstance("ec2") and atime<"-2d" | clean
 // highlight-next-line
 [ { "id": "abc" "desired": { "clean": true }, "reported": { .. } }, . . { "id": "xyz" "desired": { "clean": true }, "reported": { .. } }, ]
 ```
@@ -39,5 +39,5 @@ clean <reason>
 ```
 
 ```bash title="Mark all unused EBS volume older than 30 days that had no I/O during the past 7 days for cleaning"
-> query is(volume) and ctime < -30d and atime < -7d and mtime < -7d and volume_status = available | clean "older than 30d with more then 7d of not beeing used"
+> search is(volume) and ctime < -30d and atime < -7d and mtime < -7d and volume_status = available | clean "older than 30d with more then 7d of not beeing used"
 ```

--- a/docs/reference/cli/descendants.md
+++ b/docs/reference/cli/descendants.md
@@ -25,15 +25,15 @@ descendants [--with-origin] <edge_type>
 ## Examples
 
 ```bash title="Equivalent to query is(aws_region) -[1:]->"
-> query is(aws_region) | descendants
+> search is(aws_region) | descendants
 ```
 
 ```bash title="Equivalent to query is(aws_region) -[0:]->"
-> query is(aws_region) | descendants --with-origin
+> search is(aws_region) | descendants --with-origin
 ```
 
 ```bash
-> query is(volume_type) limit 1 | descendants --with-origin
+> search is(volume_type) limit 1 | descendants --with-origin
 // highlight-start
 kind=gcp_disk_type, name=pd-standard, age=52yr1mo, cloud=gcp, account=sre, region=us-central1, zone=us-central1-a
 kind=gcp_disk, id=881, name=disk-1, age=1yr2mo, cloud=gcp, account=sre, region=us-central1, zone=us-central1-a

--- a/docs/reference/cli/format.md
+++ b/docs/reference/cli/format.md
@@ -57,10 +57,10 @@ And the below example has a result of `[ "null:null:null" ]`:
 > json {} | format {a}:{b.c.d}:{foo.bla[23].test}
 ```
 
-This command writes the result of `query all` in JSON format to a file named `out.json`:
+This command writes the result of `search all` in JSON format to a file named `out.json`:
 
 ```bash
-> query all | format --json | write out.json
+> search all | format --json | write out.json
 ```
 
 ## See Also

--- a/docs/reference/cli/http.md
+++ b/docs/reference/cli/http.md
@@ -9,7 +9,7 @@ The shape and format of the object can be adjusted with commands such as [`list`
 You can use the [`chunk`](./chunk.md) command to send chunks of objects:
 
 ```bash title="Perform up to 3 requests, where every request will contain up to 10 elements"
-> query is(volume) limit 30 | chunk 10 | http test.foo.org
+> search is(volume) limit 30 | chunk 10 | http test.foo.org
 ```
 
 :::
@@ -50,19 +50,19 @@ http [--compress] [--timeout <seconds>] [--no-ssl-verify] [--no-body] [--nr-of-r
 ## Examples
 
 ```bash
-> query is(volume) and reported.volume_encrypted==false | https my.node.org/handle_unencrypted
+> search is(volume) and reported.volume_encrypted==false | https my.node.org/handle_unencrypted
 // highlight-next-line
 3 requests with status 200 sent.
 ```
 
 ```bash
-> query is(volume) | chunk 50 | https --compress my.node.org/handle
+> search is(volume) | chunk 50 | https --compress my.node.org/handle
 // highlight-next-line
 2 requests with status 200 sent.
 ```
 
 ```bash
-> query is(volume) | chunk 50 | https my.node.org/handle "greeting:hello from resotocore" type==volume
+> search is(volume) | chunk 50 | https my.node.org/handle "greeting:hello from resotocore" type==volume
 // highlight-next-line
 2 requests with status 200 sent.
 ```

--- a/docs/reference/cli/jq.md
+++ b/docs/reference/cli/jq.md
@@ -19,13 +19,13 @@ jq <filter>
 ## Examples
 
 ```bash title="Query all AWS EC2 instances and select the reported.id"
-> query is(aws_ec2_instance) | jq '.reported.id'
+> search is(aws_ec2_instance) | jq '.reported.id'
 // highlight-next-line
 ["id-1", "id-2"]
 ```
 
 ```bash title="Query all AWS EC2 instances and select the reported.id as id and the revision as rev"
-> query is(aws_ec2_instance) | jq '. | {id: .reported.id, rev:.revision}'
+> search is(aws_ec2_instance) | jq '. | {id: .reported.id, rev:.revision}'
 // highlight-next-line
 [{"id": "id-1", "rev": "1"}, {"id": "id-2", "rev": "5"}]
 ```

--- a/docs/reference/cli/list.md
+++ b/docs/reference/cli/list.md
@@ -49,7 +49,7 @@ The `as` clause is important if the last part of the property path is not a uniq
 ## Examples
 
 ```bash
-> query is(aws_ec2_instance) limit 3 | list
+> search is(aws_ec2_instance) limit 3 | list
 // highlight-start
 kind=aws_ec2_instance, id=1, name=sun, ctime=2020-09-10T13:24:45Z, cloud=aws, account=prod, region=us-west-2
 kind=aws_ec2_instance, id=2, name=moon, ctime=2021-09-21T01:08:11Z, cloud=aws, account=dev, region=us-west-2
@@ -58,7 +58,7 @@ kind=aws_ec2_instance, id=3, name=star, ctime=2021-09-25T23:28:40Z, cloud=aws, a
 ```
 
 ```bash
-> query is(aws_ec2_instance) limit 3 | list reported.name
+> search is(aws_ec2_instance) limit 3 | list reported.name
 // highlight-start
 name=sun
 name=moon
@@ -67,7 +67,7 @@ name=star
 ```
 
 ```bash title="Section name is missing, reported is used automatically"
-> query is(aws_ec2_instance) limit 3 | list kind, name
+> search is(aws_ec2_instance) limit 3 | list kind, name
 // highlight-start
 kind=aws_ec2_instance, name=sun
 kind=aws_ec2_instance, name=moon
@@ -76,7 +76,7 @@ kind=aws_ec2_instance, name=star
 ```
 
 ```bash
-> query is(aws_ec2_instance) limit 3 | list kind as a, name as b
+> search is(aws_ec2_instance) limit 3 | list kind as a, name as b
 // highlight-start
 a=aws_ec2_instance, b=sun
 a=aws_ec2_instance, b=moon
@@ -85,7 +85,7 @@ a=aws_ec2_instance, b=star
 ```
 
 ```bash
-> query is(aws_ec2_instance) limit 3 | list kind as a, name as b, does_not_exist
+> search is(aws_ec2_instance) limit 3 | list kind as a, name as b, does_not_exist
 // highlight-start
 a=aws_ec2_instance, b=sun
 a=aws_ec2_instance, b=moon
@@ -94,7 +94,7 @@ a=aws_ec2_instance, b=star
 ```
 
 ```bash
-> query is(aws_ec2_instance) limit 3 | list --csv kind as a, name as b, does_not_exist
+> search is(aws_ec2_instance) limit 3 | list --csv kind as a, name as b, does_not_exist
 // highlight-start
 a,b,does_not_exist
 aws_ec2_instance,sun,
@@ -104,7 +104,7 @@ aws_ec2_instance,star,
 ```
 
 ```bash
-> query is(aws_ec2_instance) limit 3 | list --markdown kind as a, name as b, does_not_exist
+> search is(aws_ec2_instance) limit 3 | list --markdown kind as a, name as b, does_not_exist
 // highlight-start
 |a               |b   |does_not_exist|
 |----------------|----|--------------|

--- a/docs/reference/cli/predecessors.md
+++ b/docs/reference/cli/predecessors.md
@@ -25,15 +25,15 @@ predecessors [--with-origin] <edge_type>
 ## Examples
 
 ```bash title="Equivalent to query is(aws_region) <--"
-> query is(aws_region) | predecessors
+> search is(aws_region) | predecessors
 ```
 
 ```bash title="Equivalent to query is(aws_region) <-[0:1]-"
-> query is(aws_region) | predecessors --with-origin
+> search is(aws_region) | predecessors --with-origin
 ```
 
 ```bash
-> query is(volume) and volume_status=available | predecessors | query is(volume_type)
+> search is(volume) and volume_status=available | predecessors | query is(volume_type)
 // highlight-start
 kind=gcp_disk_type, name=pd-standard, age=2yr1mo, cloud=gcp, account=eng, region=us-central1, zone=us-central1-a
 kind=gcp_disk_type, name=pd-standard, age=2yr1mo, cloud=gcp, account=sre, region=us-central1, zone=us-central1-a

--- a/docs/reference/cli/search.md
+++ b/docs/reference/cli/search.md
@@ -1,11 +1,11 @@
-# `query`
+# `search`
 
-The `query` command allows you to search the graph using [filters](../../concepts/search/filters.md), [traversals](../../concepts/search/traversals.md), and [functions](../../concepts/search/aggregation.md).
+The `search` command allows you to query the graph using [filters](../../concepts/search/filters.md), [traversals](../../concepts/search/traversals.md), and [functions](../../concepts/search/aggregation.md).
 
 ## Usage
 
 ```bash
-query [--include-edges] [--explain] <query>
+search [--include-edges] [--explain] <query>
 ```
 
 ### Options
@@ -17,38 +17,39 @@ query [--include-edges] [--explain] <query>
 
 ### Parameters
 
-| Parameter | Description      | Required? | Default Value |
-| --------- | ---------------- | --------- | ------------- |
-| `query`   | Query to execute | ✔️        | N/A           |
+| Parameter | Description             | Required? | Default Value |
+| --------- | ----------------------- | --------- | ------------- |
+| `query`   | Search query to execute | ✔️        | N/A           |
 
 ### Aliases
 
 - `match`
+- `query`
 
 ## Examples
 
 ```bash title="Find accounts across all cloud providers"
-> query is(account)
+> search is(account)
 ```
 
 ```bash title="Find all AWS accounts"
-> query is(aws_account)
+> search is(aws_account)
 ```
 
 ```bash title="Find all AWS accounts more than 2 weeks old"
-> query is(aws_account) and age>2w
+> search is(aws_account) and age>2w
 ```
 
 ```bash title="Find all AWS accounts that are either older than 2 weeks or have more than 10 users"
-> query is(aws_account) and (age>2w or users<10)
+> search is(aws_account) and (age>2w or users<10)
 ```
 
 ```bash title="Find 3 AWS accounts that are are either older than 2 weeks or have more than 10 users"
-> query is(aws_account) and (age>2w or users>10) limit 3
+> search is(aws_account) and (age>2w or users>10) limit 3
 ```
 
 ```bash title="Find the 3 AWS accounts that are more than 2 weeks old with the greatest number of users"
-> query is(aws_account) and age>2w sort users desc limit 3
+> search is(aws_account) and age>2w sort users desc limit 3
 ```
 
 ## See Also

--- a/docs/reference/cli/search.md
+++ b/docs/reference/cli/search.md
@@ -1,6 +1,6 @@
 # `search`
 
-The `search` command allows you to query the graph using [filters](../../concepts/search/filters.md), [traversals](../../concepts/search/traversals.md), and [functions](../../concepts/search/aggregation.md).
+The `search` command allows you to search the graph using [filters](../../concepts/search/filters.md), [traversals](../../concepts/search/traversals.md), and [functions](../../concepts/search/aggregation.md).
 
 ## Usage
 

--- a/docs/reference/cli/successors.md
+++ b/docs/reference/cli/successors.md
@@ -25,15 +25,15 @@ successors [--with-origin] <edge_type>
 ## Examples
 
 ```bash title="Equivalent to query is(aws_region) -->"
-> query is(aws_region) | successors
+> search is(aws_region) | successors
 ```
 
 ```bash title="Equivalent to query is(aws_region) -[0:1]->"
-> query is(aws_region) | successors --with-origin
+> search is(aws_region) | successors --with-origin
 ```
 
 ```bash
-> query is(volume_type) | successors | query is(volume)
+> search is(volume_type) | successors | query is(volume)
 // highlight-start
 kind=gcp_disk, id=16, name=gke16, age=8mo29d, cloud=gcp, account=eng, region=us-west1, zone=us-west1-a
 kind=gcp_disk, id=26, name=gke26, age=8mo29d, cloud=gcp, account=eng, region=us-west1, zone=us-west1-a

--- a/docs/reference/cli/tag.md
+++ b/docs/reference/cli/tag.md
@@ -48,9 +48,9 @@ tag delete [--nowait] <tag>
 ## Examples
 
 ```bash title="update tag owner of instance i-039e06bb2539e5484 if present, create if new"
-> query id = i-039e06bb2539e5484 | tag update owner lukas
+> search id = i-039e06bb2539e5484 | tag update owner lukas
 ```
 
 ```bash title="delete tag owner from instance i-039e06bb2539e5484"
-> query id = i-039e06bb2539e5484 | tag delete owner
+> search id = i-039e06bb2539e5484 | tag delete owner
 ```

--- a/docs/reference/data-models/README.md
+++ b/docs/reference/data-models/README.md
@@ -149,25 +149,25 @@ Resoto also introduces some additional simple types like `datetime` or `date`. T
 Example: Let us assume a user want to query a resource by creation time. According to the model we would need to filter for the `ctime` property. Since Resoto knows the type of `ctime` (which is of kind datetime), it can do its best to interpret the value given by the user.
 
 ```bash
-> query ctime < "2018-09-28"
+> search ctime < "2018-09-28"
 ```
 
 `ctime` is of type datetime. datetime is stored in Resoto always as ISO formatted datetime string. To make this query effective, the term `"2018-09-28"` is coerced into a valid datetime. Depending on the server time the value would be evaluated to something like:
 
 ```bash
-> query ctime < "2021-09-28T22:00:00Z"
+> search ctime < "2021-09-28T22:00:00Z"
 ```
 
 This also allows the usage of relative times, when the type of the property is known as datetime. If we want to query resources, that have been created in the last 3 days, we could express this with a relative datetime.
 
 ```bash
-> query ctime > "-3d"
+> search ctime > "-3d"
 ```
 
 This translates the term `"-3d"` using the current server time into a valid datetime. On my machine this translates into:
 
 ```bash
-> query ctime > "2021-09-26T08:13:56Z"
+> search ctime > "2021-09-26T08:13:56Z"
 ```
 
 The special type `any` is only used in scenarios, when the type is really not known and could be anything. Coercing is not possible for such a type.

--- a/news/2022-01-18-v2.0.0a10.md
+++ b/news/2022-01-18-v2.0.0a10.md
@@ -135,7 +135,7 @@ Writing queries can be a complex task.
 
 To give some guidance related to query runtime performance, we introduced the option to analyze a query.
 
-The [`query` command](/docs/reference/cli/query) now has an `--explain` flag, that gives insights into the query performance.
+The [`query` command](/docs/reference/cli/search) now has an `--explain` flag, that gives insights into the query performance.
 
 :::tip Example
 

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -64,7 +64,7 @@ For SREs in charge of maintaining cloud infrastructure, it's a drag. They are ty
 
 Resoto automatically cleans up drift that shouldn't be there and closes the gap.
 
-Resoto indexes resources, captures dependencies, and maps out your infrastructure in a graph so that it is understandable for a human. The graph contains metrics for each resource. Developers and SREs can query the graph with a search syntax, and create alerting and cleanup workflows.
+Resoto indexes resources, captures dependencies, and maps out your infrastructure in a graph so that it is understandable for a human. The graph contains metrics for each resource. Developers and SREs can search the graph with a search syntax, and create alerting and cleanup workflows.
 
 #### 1-Year Vision
 

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -6,7 +6,7 @@ title: About
 
 **Resoto** indexes resources, captures dependencies, and maps out your infrastructure in an understandable [graph](/docs/concepts/graph). The graph contains metrics for each [resource](/docs/reference/data-models).
 
-Developers and SREs can search the graph with a [query language](/docs/reference/cli/query), and create alerting and cleanup [workflows](/docs/concepts/automation/workflow).
+Developers and SREs can search the graph with a [search syntax](/docs/reference/cli/search), and create alerting and cleanup [workflows](/docs/concepts/automation/workflow).
 
 Metrics can be aggregated and exported to a time-series database such as [Prometheus](https://prometheus.io).
 
@@ -64,7 +64,7 @@ For SREs in charge of maintaining cloud infrastructure, it's a drag. They are ty
 
 Resoto automatically cleans up drift that shouldn't be there and closes the gap.
 
-Resoto indexes resources, captures dependencies, and maps out your infrastructure in a graph so that it is understandable for a human. The graph contains metrics for each resource. Developers and SREs can search the graph with a query language, and create alerting and cleanup workflows.
+Resoto indexes resources, captures dependencies, and maps out your infrastructure in a graph so that it is understandable for a human. The graph contains metrics for each resource. Developers and SREs can query the graph with a search syntax, and create alerting and cleanup workflows.
 
 #### 1-Year Vision
 
@@ -78,7 +78,7 @@ Resoto is an expert tool for engineers that runs on top of the [Resoto Core](/do
 
 - We keep their cloud infrastructure _permanently_ clean.
 
-- The [Resoto query language](/docs/reference/cli/query) offers an abstraction layer for engineers to query and collect metrics from their infrastructure. Think `> match is(instance) and tags.owner ~ jane`, for example, to find all compute instances across [AWS](https://aws.amazon.com) and [GCP](https://console.cloud.google.com) owned by Jane.
+- The [Resoto search syntax](/docs/concepts/search) offers an abstraction layer for engineers to query and collect metrics from their infrastructure. Think `> match is(instance) and tags.owner ~ jane`, for example, to find all compute instances across [AWS](https://aws.amazon.com) and [GCP](https://console.cloud.google.com) owned by Jane.
 
 - We collect bare-metal information. Hardware specifications differ, even for the same type of instance. Pre-deployment we give developers estimates about the fastest and/or cheapest hardware per region, and once they have the instance let them know exactly what they got.
 
@@ -108,7 +108,7 @@ We've expanded beyond the cloud, and also collect metadata from other infrastruc
 
 Say the valves of a fertilizer plant have embedded sensors. The sensors only have an analog serial interface and are not connected to the Internet. If the plant operator retrofits each valve with a [Raspberry Pi](https://raspberrypi.org), then Resoto collects data from both the Pis and the sensors, and integrates them into the overall company infrastructure graph. The plant operator builds the Resoto plug-in for the valves and defines the valve-specific primitives / attributes (e.g. `pressure`, `throughput`, `temperature`) to collect, in addition to any applicable common attributes (e.g. `atime`, `ctime`). Resoto provides an [MQTT](https://mqtt.org) bridge that integrates with existing IoT infrastructure and allows attribute updates via an industry standard protocol.
 
-Because of this abstraction via the primitives and our declarative query language—the Pis and valves are each just one more infrastructure component that users can discover, query and build workflows for. As the valves get replaced over time, their spec and even their brand may change. All the plant operator needs to do is write a new plug-in for a new spec or brand, and collect the same primitives. That means existing queries, workflows and automation for the entire plant will keep working.
+Because of this abstraction via the primitives and our declarative search syntax—the Pis and valves are each just one more infrastructure component that users can discover, query and build workflows for. As the valves get replaced over time, their spec and even their brand may change. All the plant operator needs to do is write a new plug-in for a new spec or brand, and collect the same primitives. That means existing queries, workflows and automation for the entire plant will keep working.
 
 We also collect metadata from popular SaaS and software tools, e.g. for identity ([Okta](https://okta.com), [OneLogin](https://onelogin.com)), source code management ([GitLab](https://gitlab.com), [GitHub](https://github.com)) or enterprise resource planning ([NetSuite](https://netsuite.com), [SAP](https://www.sap.com/products/enterprise-management-erp.html)). These tools are now sources, not just destinations or integrations where we export to.
 
@@ -170,10 +170,10 @@ With our open source and plug-in approach, we can support any and all of these n
 
 But the basic properties will stay the same—there's going to be some resource connected to some network, and the resources will have properties and attributes. As long as these primitives hold true, we can collect them and be useful. We may start with a limited set of primitives for each new infrastructure and its resources, but over time our coverage and depth will always go up.
 
-- We will replace point solutions to understand and map out any of these new types of infrastructures. There will always be a tension between a monolithic management layer that ships with a product, vs. a platform like ours.
+- We will replace point solutions to understand and map out any of these new types of infrastructures. There will always be tension between a monolithic management layer that ships with a product versus a platform like ours.
 
-- Our plug-in, no-code and query language approach lowers the barrier to work with any type of infrastructure. We think customers will value that simplicity and adoption speed.
+- Our plug-in, no-code, and search syntax approach lowers the barrier to work with any type of infrastructure. We think customers will value that simplicity and adoption speed.
 
-- Because we cover all these platforms, with a large reach, we're becoming a de-facto standard that other companies adopt when they ship their products and infrastructure elements. We attract more developers and creators that want to build custom apps.
+- Because we cover all these platforms with a large reach, we're becoming the de-facto standard that other companies adopt when they ship their products and infrastructure elements. We attract more developers and creators that want to build custom apps.
 
-- We've launched a Marketplace where our community of developers and ISVs can develop, distribute and monetize their services and infrastructure workflow apps.
+- We've launched a marketplace where our community of developers and ISVs can develop, distribute and monetize their services and infrastructure workflow applications.

--- a/static/_redirects
+++ b/static/_redirects
@@ -44,6 +44,7 @@ https://news.resoto.com/*                   https://resoto.com/news/:splat 301!
 /docs/reference/cli/predecessor             /docs/reference/cli/predecessors
 /docs/reference/cli/successor               /docs/reference/cli/successors
 
+/docs/reference/cli/query                   /docs/reference/cli/search
 /docs/reference/cli/query/basic-queries     /docs/concepts/search/filters
 /docs/reference/cli/query/nesting           /docs/concepts/search/merging-nodes
 /docs/reference/cli/query/subqueries        /docs/concepts/search/merging-nodes


### PR DESCRIPTION
# Description

The `query` command is now `search`.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
