### PR TITLE
feat(codeblock/copybutton): swizzle CodeBlock/CopyButton to remove leading shell signs in codeblock

### DIFF
--- a/docs/concepts/security.md
+++ b/docs/concepts/security.md
@@ -30,8 +30,8 @@ The [Resoto Shell (`resh`)](components/shell.md) can be used to create custom ce
 
 ```
 > certificate create --common-name arangodb.local --dns-names arangodb.local localhost --ip-addresses 127.0.0.1
-Received a file arangodb.key, which is stored to ./arangodb.key.
-Received a file arangodb.crt, which is stored to ./arangodb.crt.
+​Received a file arangodb.key, which is stored to ./arangodb.key.
+​Received a file arangodb.crt, which is stored to ./arangodb.crt.
 ```
 
 See `help certificate` for details.
@@ -85,7 +85,7 @@ The following will return http headers that contain a valid JWT for the provided
 ```python
 >>> from resotolib.jwt import encode_jwt_to_headers
 >>> encode_jwt_to_headers(http_headers={}, payload={}, psk="changeme", expire_in=3600)
-{'Authorization': 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInNhbHQiOiJuSVEzU3M5TGVNS1JHYUNQUEJxMnlBPT0ifQ.eyJleHAiOjE2NDkzNzI1MTR9.KXAmijfSsV-taO3890qJNzXKXng1u38eU6PTrDYTgVs'}
+​{'Authorization': 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInNhbHQiOiJuSVEzU3M5TGVNS1JHYUNQUEJxMnlBPT0ifQ.eyJleHAiOjE2NDkzNzI1MTR9.KXAmijfSsV-taO3890qJNzXKXng1u38eU6PTrDYTgVs'}
 ```
 
 ### Executing Resoto CLI Commands with `curl`
@@ -93,7 +93,7 @@ The following will return http headers that contain a valid JWT for the provided
 Use the retrieved CA cert and generated http headers with `curl` in a shell to talk to the Resoto API.
 
 ```bash
-auth_header="Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInNhbHQiOiJuSVEzU3M5TGVNS1JHYUNQUEJxMnlBPT0ifQ.eyJleHAiOjE2NDkzNzI1MTR9.KXAmijfSsV-taO3890qJNzXKXng1u38eU6PTrDYTgVs"
-resoto_command="search is(resource) | count"
-curl --cacert resoto_ca.crt -H "$auth_header" -H "Content-Type: text/plain" -H "Accept: application/json" -X POST -d "$resoto_command" https://localhost:8900/cli/execute
+$ auth_header="Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInNhbHQiOiJuSVEzU3M5TGVNS1JHYUNQUEJxMnlBPT0ifQ.eyJleHAiOjE2NDkzNzI1MTR9.KXAmijfSsV-taO3890qJNzXKXng1u38eU6PTrDYTgVs"
+$ resoto_command="search is(resource) | count"
+$ curl --cacert resoto_ca.crt -H "$auth_header" -H "Content-Type: text/plain" -H "Accept: application/json" -X POST -d "$resoto_command" https://localhost:8900/cli/execute
 ```

--- a/docs/getting-started/installing-with-docker.md
+++ b/docs/getting-started/installing-with-docker.md
@@ -36,7 +36,7 @@ Resoto publishes packages for x86 and ARM architectures for every proper release
 :::
 
 ```bash
-docker-compose up -d
+$ docker-compose up -d
 ```
 
 Docker Compose will start all components and set up the system. This process should not take more than 1-3 minutes depending on your machine and internet connection.
@@ -46,7 +46,7 @@ Docker Compose will start all components and set up the system. This process sho
 The `resh` command starts an interactive shell session with Resoto. To access the [Resoto Shell](../concepts/components/shell.md) interface, simply execute:
 
 ```bash
-docker-compose run resotoshell
+$ docker-compose run resotoshell
 ```
 
 ### Configuring Resoto
@@ -64,5 +64,5 @@ When a new version of Resoto is available, simply edit the container image tag (
 Then, run the following command from the directory containing the `docker-compose.yml` file:
 
 ```bash
-docker-compose up -d
+$ docker-compose up -d
 ```

--- a/docs/getting-started/installing-with-kubernetes.md
+++ b/docs/getting-started/installing-with-kubernetes.md
@@ -20,12 +20,12 @@ If you don't have ArangoDB, you can use the operator to install it. See more inf
 You can use the following commands to install the database:
 
 ```bash
-helm repo add arangodb https://arangodb.github.io/kube-arangodb
-helm repo update
-helm install kube-arangodb-crd arangodb/kube-arangodb-crd
-helm install kube-arangodb arangodb/kube-arangodb
+$ helm repo add arangodb https://arangodb.github.io/kube-arangodb
+$ helm repo update
+$ helm install kube-arangodb-crd arangodb/kube-arangodb-crd
+$ helm install kube-arangodb arangodb/kube-arangodb
 
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: "database.arangodb.com/v1alpha"
 kind: "ArangoDeployment"
 metadata:
@@ -46,7 +46,7 @@ These instructions were tested with version 1.2.8 of the operator.
 Wait until the ArangoDB deployment is ready. You can check the conditions in the status to see that it is ready:
 
 ```bash
-kubectl wait --for=condition=ready arangodeployment/single-server
+$ kubectl wait --for=condition=ready arangodeployment/single-server
 ```
 
 ### Create Helm Values File
@@ -68,13 +68,13 @@ See [`values.yaml`](https://github.com/someengineering/resoto/blob/main/kubernet
 Clone the [`someengineering/resoto`](https://github.com/someengineering/resoto) repository:
 
 ```bash
-git clone https://github.com/someengineering/resoto
+$ git clone https://github.com/someengineering/resoto
 ```
 
 Next, install Resoto using Helm:
 
 ```bash
-helm install resoto ./resoto/kubernetes/chart --set image.tag={{latestRelease}} -f resoto-values.yaml
+$ helm install resoto ./resoto/kubernetes/chart --set image.tag={{latestRelease}} -f resoto-values.yaml
 ```
 
 And just like that, you have Resoto running in Kubernetes! A collect run will begin automatically. This first collect usually takes less than 3 minutes.
@@ -86,7 +86,7 @@ The `resh` command is used to interact with [`resotocore`](../concepts/component
 To access the [Resoto Shell](../concepts/components/shell.md) interface, simply execute:
 
 ```bash
-kubectl exec -it service/resoto-resotocore -- resh
+$ kubectl exec -it service/resoto-resotocore -- resh
 ```
 
 ### Configuring Resoto
@@ -106,7 +106,7 @@ Once Resoto has completed its first collect run, you can try [performing some se
 Some cloud providers like GCP provide a file to access resources. This file needs to be passed to the worker. You can use Helm values `resotoworker.volumes`, and `resotoworker.volumeMounts` to inject credentials and their configuration to [`resotoworker`](../concepts/components/worker.md).
 
 ```bash
-kubectl -n resoto create secret generic resoto-auth \
+$ kubectl -n resoto create secret generic resoto-auth \
   --from-file=GOOGLE_APPLICATION_CREDENTIALS=<PATH TO SERVICE ACCOUNT JSON CREDS>
 ```
 

--- a/docs/getting-started/performing-searches.md
+++ b/docs/getting-started/performing-searches.md
@@ -8,15 +8,15 @@ pagination_prev: getting-started/configuring-resoto
 Resoto's search syntax is quite powerful and has many features. Once Resoto has finished its first collect run, we suggest trying these example queries:
 
 ```bash title="Search all resources for a property with value foo"
-search "foo"
+> search "foo"
 ```
 
 ```bash title="Get number of all collected resources"
-search all | count
+> search all | count
 ```
 
 ```bash title="Get number of all collected resources by kind"
-search all | count kind
+> search all | count kind
 ```
 
 ```bash title="Get list of all the compute instances"
@@ -24,33 +24,33 @@ search all | count kind
 ```
 
 ```bash title="Get list of name, type, cores, and memory for each account in csv format"
-search is(instance) | list --csv name, instance_type, instance_cores as cores,
+> search is(instance) | list --csv name, instance_type, instance_cores as cores,
   instance_memory as memory, /ancestors.account.reported.name as account
 ```
 
 ```bash title="Write list of instance IDs and their creation times as markdown table to outfile.md"
-search is(instance) | list --markdown id, ctime | write outfile.md
+> search is(instance) | list --markdown id, ctime | write outfile.md
 ```
 
 ```bash title="Get list of all compute instances with more than two CPU cores"
-search is(instance) and instance_cores > 2
+> search is(instance) and instance_cores > 2
 ```
 
 ```bash title="Get all instances and display the metadata of the last instance"
-search is(instance) | tail -1 | dump
+> search is(instance) | tail -1 | dump
 ```
 
 ```bash title="Get list volumes that are not in use, larger than 10GB, older than 30 days, and with no I/O during the past 7 days"
-search is(volume) and volume_status != in-use and
+> search is(volume) and volume_status != in-use and
   volume_size > 10 and age > 30d and last_access > 7d
 ```
 
 ```bash title="Count the number of EC2 instances by account ID"
-search is(aws_ec2_instance) | count /ancestors.account.reported.id
+> search is(aws_ec2_instance) | count /ancestors.account.reported.id
 ```
 
 ```bash title="Aggregate RAM usage (bytes) data grouped by cloud, account, region, and instance type"
-search is(instance) and instance_status == running | aggregate
+> search is(instance) and instance_status == running | aggregate
   /ancestors.cloud.reported.name as cloud,
   /ancestors.account.reported.name as account,
   /ancestors.region.reported.name as region,
@@ -58,7 +58,7 @@ search is(instance) and instance_status == running | aggregate
 ```
 
 ```bash title="Aggregate hourly instance cost grouped by cloud, account, region, and type from the cost information associated with the instance_type higher up in the graph"
-search is(instance) and instance_status == running | aggregate
+> search is(instance) and instance_status == running | aggregate
   /ancestors.cloud.reported.name as cloud,
   /ancestors.account.reported.name as account,
   /ancestors.region.reported.name as region,

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ Welcome to the Resoto documentation!
 ```bash title="Hello World in Resoto 👋🌎"
 > search is(resource) | count
 // highlight-start
-total matched: 459241
-total unmatched: 0
+​total matched: 459241
+​total unmatched: 0
 // highlight-end
 ```
 

--- a/patches/copybutton.patch
+++ b/patches/copybutton.patch
@@ -1,0 +1,33 @@
+diff --git a/src/theme/CodeBlock/CopyButton/index.js b/src/theme/CodeBlock/CopyButton/index.js
+index 63a2728..ea0de6e 100644
+--- a/src/theme/CodeBlock/CopyButton/index.js
++++ b/src/theme/CodeBlock/CopyButton/index.js
+@@ -4,16 +4,27 @@
+  * This source code is licensed under the MIT license found in the
+  * LICENSE file in the root directory of this source tree.
+  */
+ import React, {useCallback, useState, useRef, useEffect} from 'react';
+ import clsx from 'clsx';
+ import copy from 'copy-text-to-clipboard';
+ import {translate} from '@docusaurus/Translate';
+ import styles from './styles.module.css';
+ export default function CopyButton({code}) {
+   const [isCopied, setIsCopied] = useState(false);
+   const copyTimeout = useRef(undefined);
+   const handleCopyCode = useCallback(() => {
+-    copy(code);
++    copy(
++      code
++        .split('\n')
++        .map((str) =>
++          str
++            .replace(/^[>$]\s*/, '')
++            .replace(/^\s+$/, '')
++            .replace(/^\u200b.*/, '')
++        )
++        .filter((str) => str)
++        .join('\n')
++    );
+     setIsCopied(true);
+     copyTimeout.current = window.setTimeout(() => {
+       setIsCopied(false);

--- a/patches/copybutton.patch
+++ b/patches/copybutton.patch
@@ -21,6 +21,7 @@ index 63a2728..ea0de6e 100644
 +        .split('\n')
 +        .map((str) =>
 +          str
++            .replace(/^>{3}\s*/, '')
 +            .replace(/^[>$]\s*/, '')
 +            .replace(/^\s+$/, '')
 +            .replace(/^\u200b.*/, '')

--- a/patches/copybutton.sh
+++ b/patches/copybutton.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd ..
+npm run swizzle @docusaurus/theme-classic CodeBlock/CopyButton -- --eject --danger
+git apply patches/copybutton.patch

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -18,6 +18,7 @@ export default function CopyButton({ code }) {
         .split('\n')
         .map((str) =>
           str
+            .replace(/^>{3}\s*/, '')
             .replace(/^[>$]\s*/, '')
             .replace(/^\s+$/, '')
             .replace(/^\u200b.*/, '')

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -51,9 +51,10 @@ export default function CopyButton({ code }) {
       className={clsx(
         styles.copyButton,
         'clean-btn',
-        isCopied && styles.copyButtonCopied,
+        isCopied && styles.copyButtonCopied
       )}
-      onClick={handleCopyCode}>
+      onClick={handleCopyCode}
+    >
       <span className={styles.copyButtonIcons} aria-hidden="true">
         <svg className={styles.copyButtonIcon} viewBox="0 0 24 24">
           <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -24,7 +24,6 @@ export default function CopyButton({ code }) {
         )
         .filter((str) => str)
         .join('\n')
-        .concat('\n')
     );
     setIsCopied(true);
     copyTimeout.current = window.setTimeout(() => {

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -16,7 +16,7 @@ export default function CopyButton({ code }) {
     copy(
       code
         .split('\n')
-        .map((str) => str.replace(/^[>$]\s*/, ''))
+        .map((str) => str.replace(/^[>$]\s*/, '')) // remove leading > and $ from copied code block
         .join('\n')
     );
     setIsCopied(true);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -17,6 +17,7 @@ export default function CopyButton({ code }) {
       code
         .split('\n')
         .map((str) => str.replace(/^[>$]\s*/, '').replace(/^\u200b.*/, '')) // remove leading > and $ from copied code block
+        .filter((str) => str)
         .join('\n')
     );
     setIsCopied(true);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -16,7 +16,7 @@ export default function CopyButton({ code }) {
     copy(
       code
         .split('\n')
-        .map((str) => str.replace(/^[>$]\s*/, '')) // remove leading > and $ from copied code block
+        .map((str) => str.replace(/^[>$]\s*/, '').replace(/^\u200b.*/, '')) // remove leading > and $ from copied code block
         .join('\n')
     );
     setIsCopied(true);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -16,9 +16,7 @@ export default function CopyButton({ code }) {
     copy(
       code
         .split('\n')
-        .map((str) =>
-          str.length && str.charAt(0) == '>' ? str.substr(1) : str
-        )
+        .map((str) => str.replace(/^[>$]\s*/, ''))
         .join('\n')
     );
     setIsCopied(true);

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { translate } from '@docusaurus/Translate';
+import clsx from 'clsx';
+import copy from 'copy-text-to-clipboard';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import styles from './styles.module.css';
+export default function CopyButton({ code }) {
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeout = useRef(undefined);
+  const handleCopyCode = useCallback(() => {
+    copy(
+      code
+        .split('\n')
+        .map((str) =>
+          str.length && str.charAt(0) == '>' ? str.substr(1) : str
+        )
+        .join('\n')
+    );
+    setIsCopied(true);
+    copyTimeout.current = window.setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
+  }, [code]);
+  useEffect(() => () => window.clearTimeout(copyTimeout.current), []);
+  return (
+    <button
+      type="button"
+      aria-label={
+        isCopied
+          ? translate({
+              id: 'theme.CodeBlock.copied',
+              message: 'Copied',
+              description: 'The copied button label on code blocks',
+            })
+          : translate({
+              id: 'theme.CodeBlock.copyButtonAriaLabel',
+              message: 'Copy code to clipboard',
+              description: 'The ARIA label for copy code blocks button',
+            })
+      }
+      title={translate({
+        id: 'theme.CodeBlock.copy',
+        message: 'Copy',
+        description: 'The copy button label on code blocks',
+      })}
+      className={clsx(
+        styles.copyButton,
+        'clean-btn',
+        isCopied && styles.copyButtonCopied,
+      )}
+      onClick={handleCopyCode}>
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <svg className={styles.copyButtonIcon} viewBox="0 0 24 24">
+          <path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z" />
+        </svg>
+        <svg className={styles.copyButtonSuccessIcon} viewBox="0 0 24 24">
+          <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+        </svg>
+      </span>
+    </button>
+  );
+}

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -16,7 +16,12 @@ export default function CopyButton({ code }) {
     copy(
       code
         .split('\n')
-        .map((str) => str.replace(/^[>$]\s*/, '').replace(/^\u200b.*/, '')) // remove leading > and $ from copied code block
+        .map((str) =>
+          str
+            .replace(/^[>$]\s*/, '')
+            .replace(/^\s+$/, '')
+            .replace(/^\u200b.*/, '')
+        )
         .filter((str) => str)
         .join('\n')
     );

--- a/src/theme/CodeBlock/CopyButton/index.js
+++ b/src/theme/CodeBlock/CopyButton/index.js
@@ -24,6 +24,7 @@ export default function CopyButton({ code }) {
         )
         .filter((str) => str)
         .join('\n')
+        .concat('\n')
     );
     setIsCopied(true);
     copyTimeout.current = window.setTimeout(() => {

--- a/src/theme/CodeBlock/CopyButton/styles.module.css
+++ b/src/theme/CodeBlock/CopyButton/styles.module.css
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.copyButton {
+  display: flex;
+  background: inherit;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+  transition: opacity 200ms ease-in-out;
+  opacity: 0;
+}
+
+.copyButton:focus-visible,
+.copyButton:hover,
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .copyButton:not(.copyButtonCopied) {
+  opacity: 0.4;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all 0.15s ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}


### PR DESCRIPTION
# Description

Swizzle CodeBlock/CopyButton to remove leading > and $ signs when copying to clipboard and completely remove lines starting with [`\u200b` (ZERO WIDTH SPACE)](https://unicode-table.com/en/200B/).

The updated code blocks in various files are mainly for testing the JS code. There's more docs to be updated once this is merged.

Added `patches/copybutton.patch/.sh` files to make it easy to reapply the swizzle on upgrades.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
