### PR TITLE
fix(docs): use new ApiDocMdx component for API reference

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,13 +5,7 @@ hide_table_of_contents: true
 # API
 
 ```mdx-code-block
-import Redoc from '@theme/Redoc';
-import useSpecData from '@theme/useSpecData';
-
-export const ApiDoc = () => {
-  const specData = useSpecData('resotocore');
-  return <Redoc {...specData} />;
-}
+import ApiDocMdx from '@theme/ApiDocMdx';
 ```
 
-<ApiDoc />
+<ApiDocMdx id="resotocore" />

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -274,6 +274,10 @@ html[data-theme='dark'] .docusaurus-highlight-code-line {
   fill: var(--ifm-color-primary);
 }
 
+.api-info {
+  display: none;
+}
+
 @media screen and (max-width: 996px) {
   .navbar__items .navbar-icon-link > .navLinklabel {
     display: none;


### PR DESCRIPTION
# Description

Redocusaurus has a component designed to be embedded in docs pages as of v1.1.0. This component gives the API reference less of a "squished" appearance due to the its slightly modified layout.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
