### PR TITLE
fix(docs): update module name

### DIFF
--- a/docs/contributing/components.md
+++ b/docs/contributing/components.md
@@ -53,7 +53,7 @@ git clone https://github.com/<your_github_username>/resoto.git
 
 This will create a directory named `resoto` in your current working directory.
 
-Next, add a remote pointing to the upstream repository (as opposted to your fork) named `upstream`:
+Next, add a remote pointing to the upstream repository (as opposed to your fork) named `upstream`:
 
 ```bash
 git remote add upstream https://github.com/someengineering/resoto.git

--- a/docs/contributing/components.md
+++ b/docs/contributing/components.md
@@ -117,7 +117,7 @@ You can now start each of the Resoto components:
 
 ```bash
 cd resotocore
-python -m core
+python -m resotocore
 ```
 
 </TabItem>

--- a/docs/contributing/components.md
+++ b/docs/contributing/components.md
@@ -96,7 +96,7 @@ venv\Scripts\activate.bat
 
 ### Starting the Database
 
-Start [ArangoDB](https://arangodb.com) (using `systemctl` on Linux, by clicking the application icon in macOS, etc.).
+Start [ArangoDB](https://arangodb.com) (using `systemctl` on Linux, by clicking the application icon in macOS, etc.). If you used homebrew to install ArangoDB run `/usr/local/Cellar/arangodb/<VERSION>/sbin/arangod &`.
 
 Depending on the installation method used for [ArangoDB](https://arangodb.com), [authentication may or may not be enabled on the built-in `root` user account](https://www.arangodb.com/docs/stable/getting-started-installation.html#securing-the-installation). The installation process either prompted for the `root` password (Debian, Windows), configured a random password (Red Hat), or set the password to an empty string.
 

--- a/docs/contributing/components.md
+++ b/docs/contributing/components.md
@@ -96,8 +96,6 @@ venv\Scripts\activate.bat
 
 ### Starting the Database
 
-Start ArangoDB (using `systemctl` on Linux, by clicking the application icon in macOS, etc.).
-
 Start [ArangoDB](https://arangodb.com) (using `systemctl` on Linux, by clicking the application icon in macOS, etc.).
 
 Depending on the installation method used for [ArangoDB](https://arangodb.com), [authentication may or may not be enabled on the built-in `root` user account](https://www.arangodb.com/docs/stable/getting-started-installation.html#securing-the-installation). The installation process either prompted for the `root` password (Debian, Windows), configured a random password (Red Hat), or set the password to an empty string.


### PR DESCRIPTION
# Description

- updated module name from `core` to `resotocore`
- added a note on how to start ArangoDB after homebrew installation
- removed superfluous double paragraph

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
