### PR TITLE
fix(docs): aligns description and config snippet

### DIFF
--- a/docs/getting-started/configuration/cloud-providers/aws.md
+++ b/docs/getting-started/configuration/cloud-providers/aws.md
@@ -6,7 +6,7 @@ sidebar_label: Amazon Web Services
 
 The [Amazon Web Services (AWS)](../../../reference/data-models/aws.md) collector is configured within the [Resoto Worker configuration](../index.md).
 
-Add `k8s` to the list of collectors by modifying the [Resoto Worker configuration](../index.md) as follows:
+Add `aws` to the list of collectors by modifying the [Resoto Worker configuration](../index.md) as follows:
 
 ```yaml
 resotoworker:


### PR DESCRIPTION
# Description

Aligns the text description of the configuration with the snippet. I guess this was a copy & paste mistake.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`


# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
