### PR TITLE
feat(news): 2.4.2 release notes

### DIFF
--- a/news/2022/10-05-2.4.2/index.md
+++ b/news/2022/10-05-2.4.2/index.md
@@ -8,6 +8,8 @@ tags: [release notes]
 
 ### Features
 
+- [`63d8bb52`](https://github.com/someengineering/resoto/commit/63d8bb52) <span class="badge badge--secondary">resoto</span> Revert "bump 2.4.3"
+- [`f56fcd16`](https://github.com/someengineering/resoto/commit/f56fcd16) <span class="badge badge--secondary">resoto</span> bump 2.4.3
 - [`f74ed976`](https://github.com/someengineering/resoto/commit/f74ed976) <span class="badge badge--secondary">resoto</span> bump 2.4.2
 - [`8d462c68`](https://github.com/someengineering/resoto/commit/8d462c68) <span class="badge badge--secondary">resoto</span> update the secret name
 - [`38532da1`](https://github.com/someengineering/resoto/commit/38532da1) <span class="badge badge--secondary">resoto</span> update the workflow to always publish from a branch
@@ -15,10 +17,13 @@ tags: [release notes]
 
 ### Fixes
 
+- [`fb669cb0`](https://github.com/someengineering/resoto/commit/fb669cb0) <span class="badge badge--secondary">resotocore</span> Fix api test setup (#1192)
 - [`04a0dbd5`](https://github.com/someengineering/resoto/commit/04a0dbd5) <span class="badge badge--secondary">plugins/digitalocean</span> Fix the snapshots regions collection (#1194)
 
 ### Chores
 
+- [`7bd2252e`](https://github.com/someengineering/resoto/commit/7bd2252e) <span class="badge badge--secondary">ci</span> Correct file path & link for release notes (#1211)
+- [`d1d0d668`](https://github.com/someengineering/resoto/commit/d1d0d668) <span class="badge badge--secondary">ci</span> Update path to helm chart yaml (#1210)
 - [`461547be`](https://github.com/someengineering/resoto/commit/461547be) <span class="badge badge--secondary">ci</span> Update CI for versioned docs (#1164)
 - [`459f8dde`](https://github.com/someengineering/resoto/commit/459f8dde) <span class="badge badge--secondary">ci</span> Fix release notes generator when no PR, bump helm-charts versions (#1148)
 - [`655b4ff1`](https://github.com/someengineering/resoto/commit/655b4ff1) <span class="badge badge--secondary">ci</span> Handle reversed component/group in release notes generator (#1078)


### PR DESCRIPTION
Adds automatically generated release notes for [`2.4.2`](https://github.com/someengineering/resoto/releases/tag/2.4.2).