### PR TITLE
fix(docs): restore note about Compose V1 vs V2 command

### DIFF
--- a/docs/getting-started/configure-cloud-provider-access/aws.md
+++ b/docs/getting-started/configure-cloud-provider-access/aws.md
@@ -72,6 +72,14 @@ You can specify a profile using `AWS_PROFILE` and, for local testing, SSO authen
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 
@@ -223,6 +231,14 @@ The configuration is visible to anyone with access to Resoto. You can alternativ
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 
@@ -334,6 +350,14 @@ The configuration is visible to anyone with access to Resoto. You can alternativ
      ```bash
      $ docker-compose up -d
      ```
+
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
 
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">

--- a/docs/getting-started/configure-cloud-provider-access/digitalocean.md
+++ b/docs/getting-started/configure-cloud-provider-access/digitalocean.md
@@ -83,6 +83,14 @@ Instead of specifying API tokens or secret access keys in the [Resoto Worker con
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 

--- a/docs/getting-started/configure-cloud-provider-access/gcp.md
+++ b/docs/getting-started/configure-cloud-provider-access/gcp.md
@@ -62,6 +62,14 @@ You can authenticate with [Google Cloud Platform](../../reference/data-models/gc
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 

--- a/docs/getting-started/configure-cloud-provider-access/kubernetes.md
+++ b/docs/getting-started/configure-cloud-provider-access/kubernetes.md
@@ -64,6 +64,14 @@ The easiest way to configure access to Kubernetes is to give Resoto Worker acces
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 

--- a/docs/getting-started/install-resoto/docker.md
+++ b/docs/getting-started/install-resoto/docker.md
@@ -65,6 +65,14 @@ $ docker-compose up -d
 
 Upon execution of `docker-compose up -d`, Docker Compose will start all components and set up the system. This process takes approximately 1-3 minutes, depending on your machine and internet connection.
 
+:::note
+
+[Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+:::
+
 :::info
 
 Resoto publishes packages for both x86 and ARM architectures for stable releases, but `edge` versions are only available for x86.

--- a/news/2022/04-22-2.0.2/index.md
+++ b/news/2022/04-22-2.0.2/index.md
@@ -15,9 +15,9 @@ tags: [release notes]
 
 ### Fixes
 
-- [`fb209b6`](https://github.com/someengineering/resoto/commit/fb209b6) <span class="badge badge--secondary">resotoshell</span> [resotoshell][fix] Fix rich dependency
+- [`fb209b6`](https://github.com/someengineering/resoto/commit/fb209b6) <span class="badge badge--secondary">resotoshell</span> Fix rich dependency
 - [`6ffc7f4`](https://github.com/someengineering/resoto/commit/6ffc7f4) <span class="badge badge--secondary">docker</span> Add cache version to cache key for easy invalidation ([#810](https://github.com/someengineering/resoto/pull/810))
-- [`3692fcf`](https://github.com/someengineering/resoto/commit/3692fcf) <span class="badge badge--secondary">resotocore</span> [resotocore][fix] Fix rich dependency
+- [`3692fcf`](https://github.com/someengineering/resoto/commit/3692fcf) <span class="badge badge--secondary">resotocore</span> Fix rich dependency
 - [`82e64d0`](https://github.com/someengineering/resoto/commit/82e64d0) <span class="badge badge--secondary">docker</span> copy ArangoDB dump/restore client binaries ([#806](https://github.com/someengineering/resoto/pull/806))
 - [`81fc02d`](https://github.com/someengineering/resoto/commit/81fc02d) <span class="badge badge--secondary">docker</span> Add vi and nano to Docker images ([#804](https://github.com/someengineering/resoto/pull/804))
 - [`b087485`](https://github.com/someengineering/resoto/commit/b087485) <span class="badge badge--secondary">resotolib</span> Update TLS certificate files on disk after a certain time has passed ([#803](https://github.com/someengineering/resoto/pull/803))
@@ -33,9 +33,9 @@ tags: [release notes]
 
 ### Chores
 
+- [`e4aa797`](https://github.com/someengineering/resoto/commit/e4aa797) <span class="badge badge--secondary">resoto</span> Bump 2.0.2
 - [`2f1c040`](https://github.com/someengineering/resoto/commit/2f1c040) <span class="badge badge--secondary">resoto</span> use version 2.0 as docker version in compose
 - [`1763105`](https://github.com/someengineering/resoto/commit/1763105) <span class="badge badge--secondary">resoto</span> Add documentation as release note section ([#792](https://github.com/someengineering/resoto/pull/792))
-- [`e4aa797`](https://github.com/someengineering/resoto/commit/e4aa797) <span class="badge badge--secondary">resoto</span> [resoto][chore] Bump 2.0.2
 
 <!--truncate-->
 

--- a/news/2022/04-28-2.1.0/index.md
+++ b/news/2022/04-28-2.1.0/index.md
@@ -8,7 +8,6 @@ tags: [release notes]
 
 ### Features
 
-- [`e878522`](https://github.com/someengineering/resoto/commit/e878522) <span class="badge badge--secondary">resoto</span> Bump 2.1.0
 - [`0aad50b`](https://github.com/someengineering/resoto/commit/0aad50b) <span class="badge badge--secondary">resotoshell</span> Add aggregate completer ([#825](https://github.com/someengineering/resoto/pull/825))
 - [`2d0aa6a`](https://github.com/someengineering/resoto/commit/2d0aa6a) <span class="badge badge--secondary">resoto</span> Use json as logging output format ([#824](https://github.com/someengineering/resoto/pull/824))
 - [`f6aea4a`](https://github.com/someengineering/resoto/commit/f6aea4a) <span class="badge badge--secondary">resotoshell</span> Use resotoclient in resotoshell ([#822](https://github.com/someengineering/resoto/pull/822))
@@ -52,6 +51,7 @@ tags: [release notes]
 
 ### Chores
 
+- [`e878522`](https://github.com/someengineering/resoto/commit/e878522) <span class="badge badge--secondary">resoto</span> Bump 2.1.0
 - [`74533b3`](https://github.com/someengineering/resoto/commit/74533b3) <span class="badge badge--secondary">resoto</span> Add documentation as release note section ([#792](https://github.com/someengineering/resoto/pull/792))
 - [`9d57191`](https://github.com/someengineering/resoto/commit/9d57191) <span class="badge badge--secondary">ci</span> remove individual Docker images from generated release notes ([#791](https://github.com/someengineering/resoto/pull/791))
 - [`0a27e8a`](https://github.com/someengineering/resoto/commit/0a27e8a) <span class="badge badge--secondary">docker</span> Update compose file for 2.0.0 ([#788](https://github.com/someengineering/resoto/pull/788))

--- a/news/2022/08-16-2.4.0/index.md
+++ b/news/2022/08-16-2.4.0/index.md
@@ -121,7 +121,7 @@ tags: [release notes]
 
 ### Chores
 
-- [`8b6fb111`](https://github.com/someengineering/resoto/commit/8b6fb111) <span class="badge badge--secondary">resoto</span> [resoto] bump 2.4 release
+- [`8b6fb111`](https://github.com/someengineering/resoto/commit/8b6fb111) <span class="badge badge--secondary">resoto</span> bump 2.4 release
 - [`15e2ef11`](https://github.com/someengineering/resoto/commit/15e2ef11) <span class="badge badge--secondary">resotolib, resotoworker, plugins/digitalocean</span> Refactor tag operations ([#1016](https://github.com/someengineering/resoto/pull/1016))
 - [`a5d599d7`](https://github.com/someengineering/resoto/commit/a5d599d7) <span class="badge badge--secondary">resoto</span> make baseresource kwargs only ([#1008](https://github.com/someengineering/resoto/pull/1008))
 - [`da942de7`](https://github.com/someengineering/resoto/commit/da942de7) <span class="badge badge--secondary">resoto</span> Use attrs instead of dataclasses ([#972](https://github.com/someengineering/resoto/pull/972))

--- a/news/2022/10-05-2.4.2/index.md
+++ b/news/2022/10-05-2.4.2/index.md
@@ -8,9 +8,6 @@ tags: [release notes]
 
 ### Features
 
-- [`63d8bb52`](https://github.com/someengineering/resoto/commit/63d8bb52) <span class="badge badge--secondary">resoto</span> Revert "bump 2.4.3"
-- [`f56fcd16`](https://github.com/someengineering/resoto/commit/f56fcd16) <span class="badge badge--secondary">resoto</span> bump 2.4.3
-- [`f74ed976`](https://github.com/someengineering/resoto/commit/f74ed976) <span class="badge badge--secondary">resoto</span> bump 2.4.2
 - [`8d462c68`](https://github.com/someengineering/resoto/commit/8d462c68) <span class="badge badge--secondary">resoto</span> update the secret name
 - [`38532da1`](https://github.com/someengineering/resoto/commit/38532da1) <span class="badge badge--secondary">resoto</span> update the workflow to always publish from a branch
 - [`e380b5c1`](https://github.com/someengineering/resoto/commit/e380b5c1) <span class="badge badge--secondary">resoto</span> update the dependencies in resoto-bundle
@@ -22,6 +19,7 @@ tags: [release notes]
 
 ### Chores
 
+- [`f74ed976`](https://github.com/someengineering/resoto/commit/f74ed976) <span class="badge badge--secondary">resoto</span> bump 2.4.2
 - [`7bd2252e`](https://github.com/someengineering/resoto/commit/7bd2252e) <span class="badge badge--secondary">ci</span> Correct file path & link for release notes (#1211)
 - [`d1d0d668`](https://github.com/someengineering/resoto/commit/d1d0d668) <span class="badge badge--secondary">ci</span> Update path to helm chart yaml (#1210)
 - [`461547be`](https://github.com/someengineering/resoto/commit/461547be) <span class="badge badge--secondary">ci</span> Update CI for versioned docs (#1164)

--- a/news/2022/10-11-2.4.3/index.md
+++ b/news/2022/10-11-2.4.3/index.md
@@ -9,7 +9,6 @@ tags: [release notes]
 ### Features
 
 - [`3d140cee`](https://github.com/someengineering/resoto/commit/3d140cee) <span class="badge badge--secondary">resoto</span> pin the client version
-- [`91d2d2ca`](https://github.com/someengineering/resoto/commit/91d2d2ca) <span class="badge badge--secondary">resoto</span> bump 2.4.3
 - [`20c80278`](https://github.com/someengineering/resoto/commit/20c80278) <span class="badge badge--secondary">plugins/digitalocean</span> fix cleanup in DigitalOcean plugin (#1213)
 
 ### Fixes
@@ -18,6 +17,7 @@ tags: [release notes]
 
 ### Chores
 
+- [`91d2d2ca`](https://github.com/someengineering/resoto/commit/91d2d2ca) <span class="badge badge--secondary">resoto</span> bump 2.4.3
 - [`c1b33cab`](https://github.com/someengineering/resoto/commit/c1b33cab) <span class="badge badge--secondary">ci</span> Fix release notes generation (#1217)
 - [`8427afde`](https://github.com/someengineering/resoto/commit/8427afde) <span class="badge badge--secondary">ci</span> Correct link for release notes (#1214)
 

--- a/news/2022/10-19-2.4.4/index.md
+++ b/news/2022/10-19-2.4.4/index.md
@@ -6,10 +6,6 @@ tags: [release notes]
 
 ## What's Changed
 
-### Features
-
-- [`b71b09f6`](https://github.com/someengineering/resoto/commit/b71b09f6) <span class="badge badge--secondary">resoto</span> Bump 2.4.4
-
 ### Fixes
 
 - [`0ed7e8ad`](https://github.com/someengineering/resoto/commit/0ed7e8ad) <span class="badge badge--secondary">docker</span> Create swap file for ARM builds
@@ -17,6 +13,7 @@ tags: [release notes]
 
 ### Chores
 
+- [`b71b09f6`](https://github.com/someengineering/resoto/commit/b71b09f6) <span class="badge badge--secondary">resoto</span> Bump 2.4.4
 - [`c5c9414d`](https://github.com/someengineering/resoto/commit/c5c9414d) <span class="badge badge--secondary">resotocore</span> Add RESOTOCORE_ANALYTICS_OPT_OUT to docker-compose.yml (#1185)
 
 <!--truncate-->

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@typescript-eslint/eslint-plugin": "5.40.1",
     "@typescript-eslint/parser": "5.40.1",
     "commitizen": "4.2.5",
-    "eslint": "8.25.0",
+    "eslint": "8.26.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-formatjs": "4.3.4",
     "eslint-plugin-jsx-a11y": "6.6.1",

--- a/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/aws.md
+++ b/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/aws.md
@@ -72,6 +72,14 @@ You can specify a profile using `AWS_PROFILE` and, for local testing, SSO authen
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 
@@ -223,6 +231,14 @@ The configuration is visible to anyone with access to Resoto. You can alternativ
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 
@@ -334,6 +350,14 @@ The configuration is visible to anyone with access to Resoto. You can alternativ
      ```bash
      $ docker-compose up -d
      ```
+
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
 
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">

--- a/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/digitalocean.md
+++ b/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/digitalocean.md
@@ -83,6 +83,14 @@ Instead of specifying API tokens or secret access keys in the [Resoto Worker con
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 

--- a/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/gcp.md
+++ b/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/gcp.md
@@ -62,6 +62,14 @@ You can authenticate with [Google Cloud Platform](../../reference/data-models/gc
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 

--- a/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/kubernetes.md
+++ b/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/kubernetes.md
@@ -64,6 +64,14 @@ The easiest way to configure access to Kubernetes is to give Resoto Worker acces
      $ docker-compose up -d
      ```
 
+     :::note
+
+     [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+     In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+     :::
+
    </TabItem>
    <TabItem value="k8s" label="Kubernetes">
 

--- a/versioned_docs/version-2.X/getting-started/install-resoto/docker.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/docker.md
@@ -65,6 +65,14 @@ $ docker-compose up -d
 
 Upon execution of `docker-compose up -d`, Docker Compose will start all components and set up the system. This process takes approximately 1-3 minutes, depending on your machine and internet connection.
 
+:::note
+
+[Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+
+In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+
+:::
+
 :::info
 
 Resoto publishes packages for both x86 and ARM architectures for stable releases, but `edge` versions are only available for x86.

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,30 +173,30 @@
     source-map "^0.5.0"
 
 "@babel/core@^7.18.5", "@babel/core@^7.18.6":
-  version "7.19.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.3.tgz#2519f62a51458f43b682d61583c3810e7dcee64c"
-  integrity sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.6.tgz#7122ae4f5c5a37c0946c066149abd8e75f81540f"
+  integrity sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.3"
+    "@babel/generator" "^7.19.6"
     "@babel/helper-compilation-targets" "^7.19.3"
-    "@babel/helper-module-transforms" "^7.19.0"
-    "@babel/helpers" "^7.19.0"
-    "@babel/parser" "^7.19.3"
+    "@babel/helper-module-transforms" "^7.19.6"
+    "@babel/helpers" "^7.19.4"
+    "@babel/parser" "^7.19.6"
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.3"
-    "@babel/types" "^7.19.3"
+    "@babel/traverse" "^7.19.6"
+    "@babel/types" "^7.19.4"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.12.5", "@babel/generator@^7.18.7", "@babel/generator@^7.19.3", "@babel/generator@^7.19.4":
-  version "7.19.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.5.tgz#da3f4b301c8086717eee9cab14da91b1fa5dcca7"
-  integrity sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==
+"@babel/generator@^7.12.5", "@babel/generator@^7.18.7", "@babel/generator@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.6.tgz#9e481a3fe9ca6261c972645ae3904ec0f9b34a1d"
+  integrity sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==
   dependencies:
     "@babel/types" "^7.19.4"
     "@jridgewell/gen-mapping" "^0.3.2"
@@ -301,19 +301,19 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz#309b230f04e22c58c6a2c0c0c7e50b216d350c30"
-  integrity sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==
+"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz#6c52cc3ac63b70952d33ee987cbee1c9368b533f"
+  integrity sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==
   dependencies:
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-simple-access" "^7.19.4"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.0"
-    "@babel/types" "^7.19.0"
+    "@babel/traverse" "^7.19.6"
+    "@babel/types" "^7.19.4"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
   version "7.18.6"
@@ -353,7 +353,7 @@
     "@babel/traverse" "^7.19.1"
     "@babel/types" "^7.19.0"
 
-"@babel/helper-simple-access@^7.18.6":
+"@babel/helper-simple-access@^7.19.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz#be553f4951ac6352df2567f7daa19a0ee15668e7"
   integrity sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==
@@ -399,7 +399,7 @@
     "@babel/traverse" "^7.19.0"
     "@babel/types" "^7.19.0"
 
-"@babel/helpers@^7.12.5", "@babel/helpers@^7.19.0":
+"@babel/helpers@^7.12.5", "@babel/helpers@^7.19.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.19.4.tgz#42154945f87b8148df7203a25c31ba9a73be46c5"
   integrity sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==
@@ -417,10 +417,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.8", "@babel/parser@^7.19.3", "@babel/parser@^7.19.4":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.4.tgz#03c4339d2b8971eb3beca5252bafd9b9f79db3dc"
-  integrity sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==
+"@babel/parser@^7.12.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.8", "@babel/parser@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.6.tgz#b923430cb94f58a7eae8facbffa9efd19130e7f8"
+  integrity sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -815,34 +815,31 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-transform-modules-amd@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.18.6.tgz#8c91f8c5115d2202f277549848874027d7172d21"
-  integrity sha512-Pra5aXsmTsOnjM3IajS8rTaLCy++nGM4v3YR4esk5PCsyg9z8NA5oQLwxzMUtDBd8F+UmVza3VxoAaWCbzH1rg==
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.19.6.tgz#aca391801ae55d19c4d8d2ebfeaa33df5f2a2cbd"
+  integrity sha512-uG3od2mXvAtIFQIh0xrpLH6r5fpSQN04gIVovl+ODLdUMANokxQLZnPBHcjmv3GxRjnqwLuHvppjjcelqUFZvg==
   dependencies:
-    "@babel/helper-module-transforms" "^7.18.6"
-    "@babel/helper-plugin-utils" "^7.18.6"
-    babel-plugin-dynamic-import-node "^2.3.3"
+    "@babel/helper-module-transforms" "^7.19.6"
+    "@babel/helper-plugin-utils" "^7.19.0"
 
 "@babel/plugin-transform-modules-commonjs@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz#afd243afba166cca69892e24a8fd8c9f2ca87883"
-  integrity sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.19.6.tgz#25b32feef24df8038fc1ec56038917eacb0b730c"
+  integrity sha512-8PIa1ym4XRTKuSsOUXqDG0YaOlEuTVvHMe5JCfgBMOtHvJKw/4NGovEGN33viISshG/rZNVrACiBmPQLvWN8xQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.18.6"
-    "@babel/helper-plugin-utils" "^7.18.6"
-    "@babel/helper-simple-access" "^7.18.6"
-    babel-plugin-dynamic-import-node "^2.3.3"
+    "@babel/helper-module-transforms" "^7.19.6"
+    "@babel/helper-plugin-utils" "^7.19.0"
+    "@babel/helper-simple-access" "^7.19.4"
 
 "@babel/plugin-transform-modules-systemjs@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.0.tgz#5f20b471284430f02d9c5059d9b9a16d4b085a1f"
-  integrity sha512-x9aiR0WXAWmOWsqcsnrzGR+ieaTMVyGyffPVA7F8cXAGt/UxefYv6uSHZLkAFChN5M5Iy1+wjE+xJuPt22H39A==
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.19.6.tgz#59e2a84064b5736a4471b1aa7b13d4431d327e0d"
+  integrity sha512-fqGLBepcc3kErfR9R3DnVpURmckXP7gj7bAlrTQyBxrigFqszZCkFkcoxzCp2v32XmwXLvbw+8Yq9/b+QqksjQ==
   dependencies:
     "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-module-transforms" "^7.19.0"
+    "@babel/helper-module-transforms" "^7.19.6"
     "@babel/helper-plugin-utils" "^7.19.0"
-    "@babel/helper-validator-identifier" "^7.18.6"
-    babel-plugin-dynamic-import-node "^2.3.3"
+    "@babel/helper-validator-identifier" "^7.19.1"
 
 "@babel/plugin-transform-modules-umd@^7.18.6":
   version "7.18.6"
@@ -945,9 +942,9 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-transform-runtime@^7.18.6":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.1.tgz#a3df2d7312eea624c7889a2dcd37fd1dfd25b2c6"
-  integrity sha512-2nJjTUFIzBMP/f/miLxEK9vxwW/KUXsdvN4sR//TmuDhe6yU2h57WmIOE12Gng3MDP/xpjUV/ToZRdcf8Yj4fA==
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz#9d2a9dbf4e12644d6f46e5e75bfbf02b5d6e9194"
+  integrity sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==
   dependencies:
     "@babel/helper-module-imports" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.19.0"
@@ -1130,9 +1127,9 @@
     "@babel/plugin-transform-typescript" "^7.18.6"
 
 "@babel/runtime-corejs3@^7.10.2", "@babel/runtime-corejs3@^7.18.6":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.4.tgz#870dbfd9685b3dad5aeb2d00841bb8b6192e3095"
-  integrity sha512-HzjQ8+dzdx7dmZy4DQ8KV8aHi/74AjEbBGTFutBmg/pd3dY5/q1sfuOGPTFGEytlQhWoeVXqcK5BwMgIkRkNDQ==
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.19.6.tgz#778471a71d915cf3b955a9201bebabfe924f872a"
+  integrity sha512-oWNn1ZlGde7b4i/3tnixpH9qI0bOAACiUs+KEES4UUCnsPjVWFlWdLV/iwJuPC2qp3EowbAqsm+0XqNwnwYhxA==
   dependencies:
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.4"
@@ -1153,23 +1150,23 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
-"@babel/traverse@^7.12.9", "@babel/traverse@^7.18.8", "@babel/traverse@^7.19.0", "@babel/traverse@^7.19.1", "@babel/traverse@^7.19.3", "@babel/traverse@^7.19.4", "@babel/traverse@^7.4.5":
-  version "7.19.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.4.tgz#f117820e18b1e59448a6c1fa9d0ff08f7ac459a8"
-  integrity sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==
+"@babel/traverse@^7.12.9", "@babel/traverse@^7.18.8", "@babel/traverse@^7.19.0", "@babel/traverse@^7.19.1", "@babel/traverse@^7.19.4", "@babel/traverse@^7.19.6", "@babel/traverse@^7.4.5":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.6.tgz#7b4c865611df6d99cb131eec2e8ac71656a490dc"
+  integrity sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.4"
+    "@babel/generator" "^7.19.6"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.19.0"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.19.4"
+    "@babel/parser" "^7.19.6"
     "@babel/types" "^7.19.4"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.12.7", "@babel/types@^7.18.10", "@babel/types@^7.18.4", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.3", "@babel/types@^7.19.4", "@babel/types@^7.4.4":
+"@babel/types@^7.12.7", "@babel/types@^7.18.10", "@babel/types@^7.18.4", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.4", "@babel/types@^7.4.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.4.tgz#0dd5c91c573a202d600490a35b33246fed8a41c7"
   integrity sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==
@@ -1179,9 +1176,9 @@
     to-fast-properties "^2.0.0"
 
 "@braintree/sanitize-url@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.0.tgz#fe364f025ba74f6de6c837a84ef44bdb1d61e68f"
-  integrity sha512-mgmE7XBYY/21erpzhexk4Cj1cyTQ9LzvnTxtzM17BJ7ERMNE6W72mQRo0I1Ud8eFJ+RVVIcBNhLFZ3GX4XFz5w==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.1.tgz#45ff061b9ded1c6e4474b33b336ebb1b986b825a"
+  integrity sha512-zr9Qs9KFQiEvMWdZesjcmRJlUck5NR+eKGS1uyKk+oYTWwlYrsoPEi6VmG6/TzBD1hKCGEimrhTgGS6hvn/xIQ==
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -1350,19 +1347,19 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@docsearch/css@3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.2.1.tgz#c05d7818b0e43b42f9efa2d82a11c36606b37b27"
-  integrity sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g==
+"@docsearch/css@3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.2.2.tgz#859572757de61037b2da5ec408f521451ac59e45"
+  integrity sha512-VB0Evx4ikS1ZlW1YVUw+vI9b3H/UXMCo4W/ZWy+n56Sho4KOqyCHcINVays91TJt7HTV/CKO3FCbm2VJg5Wipw==
 
 "@docsearch/react@^3.1.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.2.1.tgz#112ad88db07367fa6fd933d67d58421d8d8289aa"
-  integrity sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.2.2.tgz#c892ab208031d1631e09ba0e6e43c22b7a058cf2"
+  integrity sha512-1Hn2SNQUFVPrzqvaj+vxXZfsfn3rnW8CoyGAJ1LqXMY9py8GbxK8VfmJ5Z6z4LwG9849tGru/N6dp0cQO6r9Ag==
   dependencies:
     "@algolia/autocomplete-core" "1.7.1"
     "@algolia/autocomplete-preset-algolia" "1.7.1"
-    "@docsearch/css" "3.2.1"
+    "@docsearch/css" "3.2.2"
     algoliasearch "^4.0.0"
 
 "@docusaurus/core@2.1.0":
@@ -1876,10 +1873,10 @@
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"
   integrity sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==
 
-"@humanwhocodes/config-array@^0.10.5":
-  version "0.10.7"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
-  integrity sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==
+"@humanwhocodes/config-array@^0.11.6":
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.6.tgz#6a51d603a3aaf8d4cf45b42b3f2ac9318a4adc4b"
+  integrity sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==
   dependencies:
     "@humanwhocodes/object-schema" "^1.2.1"
     debug "^4.1.1"
@@ -2023,7 +2020,7 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
 
-"@nodelib/fs.walk@^1.2.3":
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
@@ -2167,9 +2164,9 @@
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sinclair/typebox@^0.24.1":
-  version "0.24.47"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.47.tgz#530b67163714356f93e82bdb871e7db4b7bc564e"
-  integrity sha512-J4Xw0xYK4h7eC34MNOPQi6IkNxGRck6n4VJpWDzXIFVTW8I/D43Gf+NfWz/v/7NHlzWOPd3+T4PJ4OqklQ2u7A==
+  version "0.24.48"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.48.tgz#bd558c6059df563d49a4d94df8e8e0510b662e3f"
+  integrity sha512-WPGpRNHbkOsfBDmh8QHU7a5NWzEuYNThST8x1cISvX0RpP+1+V8zjuJqNwGJkHGIlhdIIhv6qVYqXz2q5/gjAA==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -2367,9 +2364,9 @@
     "@types/estree" "*"
 
 "@types/eslint@*", "@types/eslint@7 || 8":
-  version "8.4.6"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.6.tgz#7976f054c1bccfcf514bff0564c0c41df5c08207"
-  integrity sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==
+  version "8.4.7"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.7.tgz#0f05a2677d1a394ff70c21a964a32d3efa05f966"
+  integrity sha512-ehM7cCt2RSFs42mb+lcmhFT9ouIlV92PuaeRGn8N8c98oMjG4Z5pJHA9b1QiCcuqnbPSHcyfiD3mlhqMaHsQIw==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -2474,9 +2471,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
-  version "18.11.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.2.tgz#c59b7641832531264fda3f1ba610362dc9a7dfc8"
-  integrity sha512-BWN3M23gLO2jVG8g/XHIRFWiiV4/GckeFIqbU/C4V3xpoBBWSMk4OZomouN0wCkfQFPqgZikyLr7DOYDysIkkw==
+  version "18.11.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
+  integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
 
 "@types/node@14 || 16 || 17", "@types/node@^17.0.5":
   version "17.0.45"
@@ -3473,9 +3470,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001407:
-  version "1.0.30001422"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz#f2d7c6202c49a8359e6e35add894d88ef93edba1"
-  integrity sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==
+  version "1.0.30001423"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz#57176d460aa8cd85ee1a72016b961eb9aca55d91"
+  integrity sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==
 
 ccount@^1.0.0:
   version "1.1.0"
@@ -5287,14 +5284,15 @@ eslint-visitor-keys@^3.3.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
-eslint@8.25.0:
-  version "8.25.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.25.0.tgz#00eb962f50962165d0c4ee3327708315eaa8058b"
-  integrity sha512-DVlJOZ4Pn50zcKW5bYH7GQK/9MsoQG2d5eDH0ebEkE8PbgzTTmtt/VTH9GGJ4BfeZCpBLqFfvsjX35UacUL83A==
+eslint@8.26.0:
+  version "8.26.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.26.0.tgz#2bcc8836e6c424c4ac26a5674a70d44d84f2181d"
+  integrity sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==
   dependencies:
     "@eslint/eslintrc" "^1.3.3"
-    "@humanwhocodes/config-array" "^0.10.5"
+    "@humanwhocodes/config-array" "^0.11.6"
     "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -5310,14 +5308,14 @@ eslint@8.25.0:
     fast-deep-equal "^3.1.3"
     file-entry-cache "^6.0.1"
     find-up "^5.0.0"
-    glob-parent "^6.0.1"
+    glob-parent "^6.0.2"
     globals "^13.15.0"
-    globby "^11.1.0"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
     js-sdsl "^4.1.4"
     js-yaml "^4.1.0"
     json-stable-stringify-without-jsonify "^1.0.1"
@@ -5886,7 +5884,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -6395,9 +6393,9 @@ image-size@^1.0.1:
     queue "6.0.2"
 
 immer@^9.0.7:
-  version "9.0.15"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.15.tgz#0b9169e5b1d22137aba7d43f8a81a495dd1b62dc"
-  integrity sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==
+  version "9.0.16"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.16.tgz#8e7caab80118c2b54b37ad43e05758cdefad0198"
+  integrity sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
@@ -6680,7 +6678,7 @@ is-path-cwd@^2.2.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
-is-path-inside@^3.0.2:
+is-path-inside@^3.0.2, is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -6869,9 +6867,9 @@ jest-worker@^29.1.2:
     supports-color "^8.0.0"
 
 joi@^17.5.0, joi@^17.6.0:
-  version "17.6.3"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.3.tgz#b8e9e143f0188884563e6de50f8b23ddcd3cb2f5"
-  integrity sha512-YlQsIaS9MHYekzf1Qe11LjTkNzx9qhYluK3172z38RxYoAUf82XMX1p1DG1H4Wtk2ED/vPdSn9OggqtDu+aTow==
+  version "17.6.4"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.4.tgz#4d9536a059ef0762c718ae98673016b3ec151abd"
+  integrity sha512-tPzkTJHZQjSFCc842QpdVpOZ9LI2txApboNUbW70qgnRB14Lzl+oWQOPdF2N4yqyiY14wBGe8lc7f/2hZxbGmw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
     "@hapi/topo" "^5.0.0"
@@ -7103,9 +7101,9 @@ loader-runner@^4.2.0:
   integrity sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==
 
 loader-utils@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
-  integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.3.tgz#d4b15b8504c63d1fc3f2ade52d41bc8459d6ede1"
+  integrity sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"


### PR DESCRIPTION
# Description

Adds notes to each place where `docker-compose` command is used.

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).