### PR TITLE
fix(docs): improve CLI doc page titles & social cards

### DIFF
--- a/docs/reference/cli/action-commands/aws.md
+++ b/docs/reference/cli/action-commands/aws.md
@@ -1,4 +1,8 @@
-# `aws`
+---
+sidebar_label: aws
+---
+
+# `aws` Command
 
 The `aws` command executes an operation on an AWS resource. The command supports the same services and operations as the AWS CLI.
 

--- a/docs/reference/cli/action-commands/clean.md
+++ b/docs/reference/cli/action-commands/clean.md
@@ -1,4 +1,8 @@
-# `clean`
+---
+sidebar_label: clean
+---
+
+# `clean` Command
 
 The `clean` command marks resources for cleaning by setting `desired.clean=true` to the resources. Resources marked as such will be removed during the next cleanup step of the `collect_and_cleanup` workflow. See [concept of workflows](../../../concepts/automation/workflow.md) for reference.
 

--- a/docs/reference/cli/action-commands/http.md
+++ b/docs/reference/cli/action-commands/http.md
@@ -1,4 +1,8 @@
-# `http`
+---
+sidebar_label: http
+---
+
+# `http` Command
 
 The `http` command sends objects in a payload to the defined HTTP(S) endpoint.
 

--- a/docs/reference/cli/action-commands/jobs/activate.md
+++ b/docs/reference/cli/action-commands/jobs/activate.md
@@ -2,7 +2,7 @@
 sidebar_label: activate
 ---
 
-# `jobs activate`
+# `jobs activate` Command
 
 The `jobs activate` command activates the triggers of a job.
 

--- a/docs/reference/cli/action-commands/jobs/add.md
+++ b/docs/reference/cli/action-commands/jobs/add.md
@@ -2,7 +2,7 @@
 sidebar_label: add
 ---
 
-# `jobs add`
+# `jobs add` Command
 
 The `jobs add` command adds a job to the task handler.
 

--- a/docs/reference/cli/action-commands/jobs/deactivate.md
+++ b/docs/reference/cli/action-commands/jobs/deactivate.md
@@ -2,7 +2,7 @@
 sidebar_label: deactivate
 ---
 
-# `jobs deactivate`
+# `jobs deactivate` Command
 
 The `jobs deactivate` command deactivates the triggers of a job, so that the job is not started if the triggers are fired.
 

--- a/docs/reference/cli/action-commands/jobs/delete.md
+++ b/docs/reference/cli/action-commands/jobs/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `jobs delete`
+# `jobs delete` Command
 
 The `jobs delete` command deletes a job.
 

--- a/docs/reference/cli/action-commands/jobs/index.md
+++ b/docs/reference/cli/action-commands/jobs/index.md
@@ -1,4 +1,8 @@
-# `jobs`
+---
+sidebar_label: jobs
+---
+
+# `jobs` Command
 
 The `jobs` command allows for the management of jobs.
 

--- a/docs/reference/cli/action-commands/jobs/list.md
+++ b/docs/reference/cli/action-commands/jobs/list.md
@@ -2,7 +2,7 @@
 sidebar_label: list
 ---
 
-# `jobs list`
+# `jobs list` Command
 
 The `jobs list` command lists all jobs.
 

--- a/docs/reference/cli/action-commands/jobs/run.md
+++ b/docs/reference/cli/action-commands/jobs/run.md
@@ -2,7 +2,7 @@
 sidebar_label: run
 ---
 
-# `jobs run`
+# `jobs run` Command
 
 The `jobs run` command runs a job.
 

--- a/docs/reference/cli/action-commands/jobs/running.md
+++ b/docs/reference/cli/action-commands/jobs/running.md
@@ -2,7 +2,7 @@
 sidebar_label: running
 ---
 
-# `jobs running`
+# `jobs running` Command
 
 The `jobs running` command lists all currently running jobs.
 

--- a/docs/reference/cli/action-commands/jobs/show.md
+++ b/docs/reference/cli/action-commands/jobs/show.md
@@ -2,7 +2,7 @@
 sidebar_label: show
 ---
 
-# `jobs show`
+# `jobs show` Command
 
 The `jobs show` command shows the definition of a job.
 

--- a/docs/reference/cli/action-commands/jobs/update.md
+++ b/docs/reference/cli/action-commands/jobs/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `jobs update`
+# `jobs update` Command
 
 The `jobs update` command updates a job.
 

--- a/docs/reference/cli/action-commands/protect.md
+++ b/docs/reference/cli/action-commands/protect.md
@@ -1,4 +1,8 @@
-# `protect`
+---
+sidebar_label: protect
+---
+
+# `protect` Command
 
 The `protect` command marks all incoming database objects as protected.
 

--- a/docs/reference/cli/action-commands/set_desired.md
+++ b/docs/reference/cli/action-commands/set_desired.md
@@ -1,4 +1,8 @@
-# `set_desired`
+---
+sidebar_label: set_desired
+---
+
+# `set_desired` Command
 
 The `set_desired` command sets one or more properties as desired for incoming database objects.
 

--- a/docs/reference/cli/action-commands/set_metadata.md
+++ b/docs/reference/cli/action-commands/set_metadata.md
@@ -1,4 +1,8 @@
-# `set_metadata`
+---
+sidebar_label: set_metadata
+---
+
+# `set_metadata` Command
 
 The `set_metadata` command sets one or more properties as metadata for incoming database objects.
 

--- a/docs/reference/cli/action-commands/tag/delete.md
+++ b/docs/reference/cli/action-commands/tag/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `tag delete`
+# `tag delete` Command
 
 The `tag delete` command deletes a tag.
 

--- a/docs/reference/cli/action-commands/tag/index.md
+++ b/docs/reference/cli/action-commands/tag/index.md
@@ -1,4 +1,8 @@
-# `tag`
+---
+sidebar_label: tag
+---
+
+# `tag` Command
 
 The `tag` command allows for mass creation, update, and deletion of tags.
 

--- a/docs/reference/cli/action-commands/tag/update.md
+++ b/docs/reference/cli/action-commands/tag/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `tag update`
+# `tag update` Command
 
 The `tag update` command updates a tag (or creates a tag if it does not exist).
 

--- a/docs/reference/cli/action-commands/workflows/index.md
+++ b/docs/reference/cli/action-commands/workflows/index.md
@@ -1,4 +1,8 @@
-# `workflows`
+---
+sidebar_label: workflows
+---
+
+# `workflows` Command
 
 The `workflows` command allows for the management of workflows.
 

--- a/docs/reference/cli/action-commands/workflows/list.md
+++ b/docs/reference/cli/action-commands/workflows/list.md
@@ -2,7 +2,7 @@
 sidebar_label: list
 ---
 
-# `workflows list`
+# `workflows list` Command
 
 The `workflows list` command lists all workflows.
 

--- a/docs/reference/cli/action-commands/workflows/run.md
+++ b/docs/reference/cli/action-commands/workflows/run.md
@@ -2,7 +2,7 @@
 sidebar_label: run
 ---
 
-# `workflows run`
+# `workflows run` Command
 
 The `workflows run` command runs a workflow.
 

--- a/docs/reference/cli/action-commands/workflows/running.md
+++ b/docs/reference/cli/action-commands/workflows/running.md
@@ -2,7 +2,7 @@
 sidebar_label: running
 ---
 
-# `workflows running`
+# `workflows running` Command
 
 The `workflows running` command lists all currently running workflows.
 

--- a/docs/reference/cli/action-commands/workflows/show.md
+++ b/docs/reference/cli/action-commands/workflows/show.md
@@ -2,7 +2,7 @@
 sidebar_label: show
 ---
 
-# `workflows show`
+# `workflows show` Command
 
 The `workflows show` command shows the definition of a workflow.
 

--- a/docs/reference/cli/format-commands/dump.md
+++ b/docs/reference/cli/format-commands/dump.md
@@ -1,4 +1,8 @@
-# `dump`
+---
+sidebar_label: dump
+---
+
+# `dump` Command
 
 The `dump` command outputs all properties of elements.
 

--- a/docs/reference/cli/format-commands/format.md
+++ b/docs/reference/cli/format-commands/format.md
@@ -1,4 +1,8 @@
-# `format`
+---
+sidebar_label: format
+---
+
+# `format` Command
 
 The `format` command creates a string from the JSON input based on the provided format string.
 

--- a/docs/reference/cli/format-commands/list.md
+++ b/docs/reference/cli/format-commands/list.md
@@ -1,4 +1,8 @@
-# `list`
+---
+sidebar_label: list
+---
+
+# `list` Command
 
 The `list` command transforms inputted JSON objects into `string`s.
 

--- a/docs/reference/cli/miscellaneous-commands/chunk.md
+++ b/docs/reference/cli/miscellaneous-commands/chunk.md
@@ -1,4 +1,8 @@
-# `chunk`
+---
+sidebar_label: chunk
+---
+
+# `chunk` Command
 
 The `chunk` command groups elements from the input stream into "chunks" of a defined size.
 

--- a/docs/reference/cli/miscellaneous-commands/echo.md
+++ b/docs/reference/cli/miscellaneous-commands/echo.md
@@ -1,4 +1,8 @@
-# `echo`
+---
+sidebar_label: echo
+---
+
+# `echo` Command
 
 The `echo` command sends the provided message downstream.
 

--- a/docs/reference/cli/miscellaneous-commands/env.md
+++ b/docs/reference/cli/miscellaneous-commands/env.md
@@ -1,4 +1,8 @@
-# `env`
+---
+sidebar_label: env
+---
+
+# `env` Command
 
 The `env` command retrieves environment variables and passes it to the output stream.
 

--- a/docs/reference/cli/miscellaneous-commands/flatten.md
+++ b/docs/reference/cli/miscellaneous-commands/flatten.md
@@ -1,4 +1,8 @@
-# `flatten`
+---
+sidebar_label: flatten
+---
+
+# `flatten` Command
 
 The `flatten` command combines groups of elements from the input stream into a stream of individual elements, preserving their original order.
 

--- a/docs/reference/cli/miscellaneous-commands/head.md
+++ b/docs/reference/cli/miscellaneous-commands/head.md
@@ -1,4 +1,8 @@
-# `head`
+---
+sidebar_label: head
+---
+
+# `head` Command
 
 The `head` command returns the first `n` elements of the input stream and discards the remainder of the stream.
 

--- a/docs/reference/cli/miscellaneous-commands/help.md
+++ b/docs/reference/cli/miscellaneous-commands/help.md
@@ -1,4 +1,8 @@
-# `help`
+---
+sidebar_label: help
+---
+
+# `help` Command
 
 The `help` commands outputs a list of all CLI commands when no argument is provided.
 

--- a/docs/reference/cli/miscellaneous-commands/jq.md
+++ b/docs/reference/cli/miscellaneous-commands/jq.md
@@ -1,4 +1,8 @@
-# `jq`
+---
+sidebar_label: jq
+---
+
+# `jq` Command
 
 The `jq` command filters and processes JSON input.
 

--- a/docs/reference/cli/miscellaneous-commands/json.md
+++ b/docs/reference/cli/miscellaneous-commands/json.md
@@ -1,4 +1,8 @@
-# `json`
+---
+sidebar_label: json
+---
+
+# `json` Command
 
 The `json` command parses JSON input.
 

--- a/docs/reference/cli/miscellaneous-commands/sleep.md
+++ b/docs/reference/cli/miscellaneous-commands/sleep.md
@@ -1,4 +1,8 @@
-# `sleep`
+---
+sidebar_label: sleep
+---
+
+# `sleep` Command
 
 The `sleep` command suspends execution for a defined interval of time.
 

--- a/docs/reference/cli/miscellaneous-commands/tail.md
+++ b/docs/reference/cli/miscellaneous-commands/tail.md
@@ -1,4 +1,8 @@
-# `tail`
+---
+sidebar_label: tail
+---
+
+# `tail` Command
 
 The `tail` command returns the last `n` elements of the input stream. The beginning of the stream is consumed but discarded.
 

--- a/docs/reference/cli/miscellaneous-commands/uniq.md
+++ b/docs/reference/cli/miscellaneous-commands/uniq.md
@@ -1,4 +1,8 @@
-# `uniq`
+---
+sidebar_label: uniq
+---
+
+# `uniq` Command
 
 The `uniq` command deduplicates input stream objects.
 

--- a/docs/reference/cli/miscellaneous-commands/write.md
+++ b/docs/reference/cli/miscellaneous-commands/write.md
@@ -1,4 +1,8 @@
-# `write`
+---
+sidebar_label: write
+---
+
+# `write` Command
 
 The `write` command outputs data to a file.
 

--- a/docs/reference/cli/search-commands/aggregate.md
+++ b/docs/reference/cli/search-commands/aggregate.md
@@ -1,4 +1,8 @@
-# `aggregate`
+---
+sidebar_label: aggregate
+---
+
+# `aggregate` Command
 
 The `aggregate` command aggregates query results over given properties and applies the defined aggregation functions.
 

--- a/docs/reference/cli/search-commands/ancestors.md
+++ b/docs/reference/cli/search-commands/ancestors.md
@@ -1,4 +1,8 @@
-# `ancestors`
+---
+sidebar_label: ancestors
+---
+
+# `ancestors` Command
 
 The `ancestors` command selects all ancestors of nodes returned in a query.
 

--- a/docs/reference/cli/search-commands/count.md
+++ b/docs/reference/cli/search-commands/count.md
@@ -1,4 +1,8 @@
-# `count`
+---
+sidebar_label: count
+---
+
+# `count` Command
 
 The `count` command returns the number of elements or properties in the piped input.
 

--- a/docs/reference/cli/search-commands/descendants.md
+++ b/docs/reference/cli/search-commands/descendants.md
@@ -1,4 +1,8 @@
-# `descendants`
+---
+sidebar_label: descendants
+---
+
+# `descendants` Command
 
 The `descendants` command selects all descendants of nodes returned in a query.
 

--- a/docs/reference/cli/search-commands/kinds.md
+++ b/docs/reference/cli/search-commands/kinds.md
@@ -1,4 +1,8 @@
-# `kinds`
+---
+sidebar_label: kinds
+---
+
+# `kinds` Command
 
 The `kinds` command retrieves information about the graph data kinds.
 

--- a/docs/reference/cli/search-commands/predecessors.md
+++ b/docs/reference/cli/search-commands/predecessors.md
@@ -1,4 +1,8 @@
-# `predecessors`
+---
+sidebar_label: predecessors
+---
+
+# `predecessors` Command
 
 The `predecessors` command selects all predecessors of nodes returned in a query.
 

--- a/docs/reference/cli/search-commands/search.md
+++ b/docs/reference/cli/search-commands/search.md
@@ -1,4 +1,8 @@
-# `search`
+---
+sidebar_label: search
+---
+
+# `search` Command
 
 The `search` command allows you to search the graph using [filters](../../search/filters.md), [traversals](../../search/traversals.md), and [functions](../../search/aggregation.md).
 

--- a/docs/reference/cli/search-commands/successors.md
+++ b/docs/reference/cli/search-commands/successors.md
@@ -1,4 +1,8 @@
-# `successors`
+---
+sidebar_label: successors
+---
+
+# `successors` Command
 
 The `successors` command selects all successors of nodes returned in a query.
 

--- a/docs/reference/cli/search-commands/templates/add.md
+++ b/docs/reference/cli/search-commands/templates/add.md
@@ -2,7 +2,7 @@
 sidebar_label: add
 ---
 
-# `templates add`
+# `templates add` Command
 
 The `templates add` command adds a search template.
 

--- a/docs/reference/cli/search-commands/templates/delete.md
+++ b/docs/reference/cli/search-commands/templates/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `templates delete`
+# `templates delete` Command
 
 The `templates delete` command deletes a search template.
 

--- a/docs/reference/cli/search-commands/templates/index.md
+++ b/docs/reference/cli/search-commands/templates/index.md
@@ -1,4 +1,8 @@
-# `templates`
+---
+sidebar_label: templates
+---
+
+# `templates` Command
 
 The `templates` command is used to access the search template library.
 

--- a/docs/reference/cli/search-commands/templates/test.md
+++ b/docs/reference/cli/search-commands/templates/test.md
@@ -2,7 +2,7 @@
 sidebar_label: test
 ---
 
-# `templates test`
+# `templates test` Command
 
 The `templates test` command tests a search template.
 

--- a/docs/reference/cli/search-commands/templates/update.md
+++ b/docs/reference/cli/search-commands/templates/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `templates update`
+# `templates update` Command
 
 The `templates update` command updates a search template.
 

--- a/docs/reference/cli/setup-commands/certificate.md
+++ b/docs/reference/cli/setup-commands/certificate.md
@@ -1,4 +1,8 @@
-# `certificate`
+---
+sidebar_label: certificate
+---
+
+# `certificate` Command
 
 The `certificate` command is used to create a new TLS certificate and key pair based on the internal root CA certificate. This can be used to create a self-signed certificate for additional components that communicate with Resoto.
 

--- a/docs/reference/cli/setup-commands/configs/delete.md
+++ b/docs/reference/cli/setup-commands/configs/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `configs delete`
+# `configs delete` Command
 
 The `configs delete` command deletes the specified configuration.
 

--- a/docs/reference/cli/setup-commands/configs/edit.md
+++ b/docs/reference/cli/setup-commands/configs/edit.md
@@ -2,7 +2,7 @@
 sidebar_label: edit
 ---
 
-# `configs edit`
+# `configs edit` Command
 
 The `configs edit` command opens the specified configuration in the locally configured text editor. Changes to the configuration will be updated, when the local file is saved and the editor has exited. It is possible to cancel an update, by not saving the file.
 

--- a/docs/reference/cli/setup-commands/configs/index.md
+++ b/docs/reference/cli/setup-commands/configs/index.md
@@ -1,4 +1,8 @@
-# `configs`
+---
+sidebar_label: configs
+---
+
+# `configs` Command
 
 The `configs` command allows for the management of component configurations.
 

--- a/docs/reference/cli/setup-commands/configs/list.md
+++ b/docs/reference/cli/setup-commands/configs/list.md
@@ -2,7 +2,7 @@
 sidebar_label: list
 ---
 
-# `configs list`
+# `configs list` Command
 
 The `configs list` command lists all configuration identifiers.
 

--- a/docs/reference/cli/setup-commands/configs/set.md
+++ b/docs/reference/cli/setup-commands/configs/set.md
@@ -2,7 +2,7 @@
 sidebar_label: set
 ---
 
-# `configs set`
+# `configs set` Command
 
 The `configs set` command assigns values to specific properties in the specified configuration.
 

--- a/docs/reference/cli/setup-commands/configs/show.md
+++ b/docs/reference/cli/setup-commands/configs/show.md
@@ -2,7 +2,7 @@
 sidebar_label: show
 ---
 
-# `configs show`
+# `configs show` Command
 
 The `configs show` command shows the specified configuration.
 

--- a/docs/reference/cli/setup-commands/configs/update.md
+++ b/docs/reference/cli/setup-commands/configs/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `configs update`
+# `configs update` Command
 
 The `configs update` command updates the specified configuration, creating it if it does not already exist.
 

--- a/docs/reference/cli/setup-commands/system/backup/create.md
+++ b/docs/reference/cli/setup-commands/system/backup/create.md
@@ -2,7 +2,7 @@
 sidebar_label: create
 ---
 
-# `system backup create`
+# `system backup create` Command
 
 The `system backup create` command creates a backup of the database.
 

--- a/docs/reference/cli/setup-commands/system/backup/index.md
+++ b/docs/reference/cli/setup-commands/system/backup/index.md
@@ -1,4 +1,8 @@
-# `system backup`
+---
+sidebar_label: backup
+---
+
+# `system backup` Command
 
 The `system backup` command allows for creating and restoring backups.
 

--- a/docs/reference/cli/setup-commands/system/backup/restore.md
+++ b/docs/reference/cli/setup-commands/system/backup/restore.md
@@ -2,7 +2,7 @@
 sidebar_label: restore
 ---
 
-# `system backup restore`
+# `system backup restore` Command
 
 The `system backup restore` command restores a backup of the database.
 

--- a/docs/reference/cli/setup-commands/system/index.md
+++ b/docs/reference/cli/setup-commands/system/index.md
@@ -1,4 +1,8 @@
-# `system`
+---
+sidebar_label: system
+---
+
+# `system` Command
 
 The `system` command allows for the management of system-wide properties.
 

--- a/docs/reference/cli/setup-commands/system/info.md
+++ b/docs/reference/cli/setup-commands/system/info.md
@@ -2,7 +2,7 @@
 sidebar_label: info
 ---
 
-# `system info`
+# `system info` Command
 
 The `system info` command prints information about the system.
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -20,7 +20,7 @@
   --ifm-color-primary-contrast-foreground: var(--ifm-color-content);
   --ifm-heading-color: var(--ifm-color-primary);
   --ifm-font-size-base: 110%;
-  --ifm-code-font-size: 80%;
+  --ifm-code-font-size: 85%;
   --ifm-font-family-base: 'Barlow', sans-serif;
   font-variation-settings: 'wght' 100, 'wdth' 500;
   --ifm-h1-font-size: 2.5rem;

--- a/src/utils/socialImageHelper.ts
+++ b/src/utils/socialImageHelper.ts
@@ -2,7 +2,7 @@ export const getImage = (title: string): string => {
   if (title) {
     return `https://resoto-og-image.vercel.app/${encodeURIComponent(
       title
-    )}.png`;
+    )}.png?md=1`;
   }
 
   return 'https://resoto-og-image.vercel.app/Cloud%20infrastructure%20intelligence%20and%20automation%20for%20**humans**.png?md=1';

--- a/versioned_docs/version-2.X/reference/cli/action-commands/clean.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/clean.md
@@ -1,4 +1,8 @@
-# `clean`
+---
+sidebar_label: clean
+---
+
+# `clean` Command
 
 The `clean` command marks resources for cleaning by setting `desired.clean=true` to the resources. Resources marked as such will be removed during the next cleanup step of the `collect_and_cleanup` workflow. See [concept of workflows](../../../concepts/automation/workflow.md) for reference.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/http.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/http.md
@@ -1,4 +1,8 @@
-# `http`
+---
+sidebar_label: http
+---
+
+# `http` Command
 
 The `http` command sends objects in a payload to the defined HTTP(S) endpoint.
 
@@ -17,7 +21,7 @@ You can use the [`chunk`](../miscellaneous-commands/chunk.md) command to send ch
 ## Usage
 
 ```bash
-http [--compress] [--timeout <seconds>] [--no-ssl-verify] [--no-body] [--nr-of-retries <num>] <http_method> <url> <headers> <query_params>
+http [--compress] [--timeout <seconds>] [--no-ssl-verify] [--no-body] [--nr-of-retries <num>] [--auth <username>:<password>] <http_method> <url> <headers> <query_params>
 ```
 
 ### Options
@@ -29,6 +33,7 @@ http [--compress] [--timeout <seconds>] [--no-ssl-verify] [--no-body] [--nr-of-r
 | `--no-ssl-verify`     | Disable SSL certificate verification                                               |
 | `--no-body`           | Send with empty request body                                                       |
 | `--nr-of-retries`     | Maximum number of retries for unsuccessful requests (non-2XX HTTP status codes) \* |
+| `--auth`              | Basic authentication username and password                                         |
 
 \* By default, requests are retried three times. There is an exponential backoff between retries.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/activate.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/activate.md
@@ -2,7 +2,7 @@
 sidebar_label: activate
 ---
 
-# `jobs activate`
+# `jobs activate` Command
 
 The `jobs activate` command activates the triggers of a job.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/add.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/add.md
@@ -2,7 +2,7 @@
 sidebar_label: add
 ---
 
-# `jobs add`
+# `jobs add` Command
 
 The `jobs add` command adds a job to the task handler.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/deactivate.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/deactivate.md
@@ -2,7 +2,7 @@
 sidebar_label: deactivate
 ---
 
-# `jobs deactivate`
+# `jobs deactivate` Command
 
 The `jobs deactivate` command deactivates the triggers of a job, so that the job is not started if the triggers are fired.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/delete.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `jobs delete`
+# `jobs delete` Command
 
 The `jobs delete` command deletes a job.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/index.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/index.md
@@ -1,4 +1,8 @@
-# `jobs`
+---
+sidebar_label: jobs
+---
+
+# `jobs` Command
 
 The `jobs` command allows for the management of jobs.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/list.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/list.md
@@ -2,7 +2,7 @@
 sidebar_label: list
 ---
 
-# `jobs list`
+# `jobs list` Command
 
 The `jobs list` command lists all jobs.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/run.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/run.md
@@ -2,7 +2,7 @@
 sidebar_label: run
 ---
 
-# `jobs run`
+# `jobs run` Command
 
 The `jobs run` command runs a job.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/running.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/running.md
@@ -2,7 +2,7 @@
 sidebar_label: running
 ---
 
-# `jobs running`
+# `jobs running` Command
 
 The `jobs running` command lists all currently running jobs.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/show.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/show.md
@@ -2,7 +2,7 @@
 sidebar_label: show
 ---
 
-# `jobs show`
+# `jobs show` Command
 
 The `jobs show` command shows the definition of a job.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/jobs/update.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/jobs/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `jobs update`
+# `jobs update` Command
 
 The `jobs update` command updates a job.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/protect.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/protect.md
@@ -1,4 +1,8 @@
-# `protect`
+---
+sidebar_label: protect
+---
+
+# `protect` Command
 
 The `protect` command marks all incoming database objects as protected.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/set_desired.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/set_desired.md
@@ -1,4 +1,8 @@
-# `set_desired`
+---
+sidebar_label: set_desired
+---
+
+# `set_desired` Command
 
 The `set_desired` command sets one or more properties as desired for incoming database objects.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/set_metadata.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/set_metadata.md
@@ -1,4 +1,8 @@
-# `set_metadata`
+---
+sidebar_label: set_metadata
+---
+
+# `set_metadata` Command
 
 The `set_metadata` command sets one or more properties as metadata for incoming database objects.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/tag/delete.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/tag/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `tag delete`
+# `tag delete` Command
 
 The `tag delete` command deletes a tag.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/tag/index.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/tag/index.md
@@ -1,4 +1,8 @@
-# `tag`
+---
+sidebar_label: tag
+---
+
+# `tag` Command
 
 The `tag` command allows for mass creation, update, and deletion of tags.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/tag/update.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/tag/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `tag update`
+# `tag update` Command
 
 The `tag update` command updates a tag (or creates a tag if it does not exist).
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/workflows/index.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/workflows/index.md
@@ -1,4 +1,8 @@
-# `workflows`
+---
+sidebar_label: workflows
+---
+
+# `workflows` Command
 
 The `workflows` command allows for the management of workflows.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/workflows/list.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/workflows/list.md
@@ -2,7 +2,7 @@
 sidebar_label: list
 ---
 
-# `workflows list`
+# `workflows list` Command
 
 The `workflows list` command lists all workflows.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/workflows/run.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/workflows/run.md
@@ -2,7 +2,7 @@
 sidebar_label: run
 ---
 
-# `workflows run`
+# `workflows run` Command
 
 The `workflows run` command runs a workflow.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/workflows/running.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/workflows/running.md
@@ -2,7 +2,7 @@
 sidebar_label: running
 ---
 
-# `workflows running`
+# `workflows running` Command
 
 The `workflows running` command lists all currently running workflows.
 

--- a/versioned_docs/version-2.X/reference/cli/action-commands/workflows/show.md
+++ b/versioned_docs/version-2.X/reference/cli/action-commands/workflows/show.md
@@ -2,7 +2,7 @@
 sidebar_label: show
 ---
 
-# `workflows show`
+# `workflows show` Command
 
 The `workflows show` command shows the definition of a workflow.
 

--- a/versioned_docs/version-2.X/reference/cli/format-commands/dump.md
+++ b/versioned_docs/version-2.X/reference/cli/format-commands/dump.md
@@ -1,4 +1,8 @@
-# `dump`
+---
+sidebar_label: dump
+---
+
+# `dump` Command
 
 The `dump` command outputs all properties of elements.
 

--- a/versioned_docs/version-2.X/reference/cli/format-commands/format.md
+++ b/versioned_docs/version-2.X/reference/cli/format-commands/format.md
@@ -1,4 +1,8 @@
-# `format`
+---
+sidebar_label: format
+---
+
+# `format` Command
 
 The `format` command creates a string from the JSON input based on the provided format string.
 

--- a/versioned_docs/version-2.X/reference/cli/format-commands/list.md
+++ b/versioned_docs/version-2.X/reference/cli/format-commands/list.md
@@ -1,4 +1,8 @@
-# `list`
+---
+sidebar_label: list
+---
+
+# `list` Command
 
 The `list` command transforms inputted JSON objects into `string`s.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/chunk.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/chunk.md
@@ -1,4 +1,8 @@
-# `chunk`
+---
+sidebar_label: chunk
+---
+
+# `chunk` Command
 
 The `chunk` command groups elements from the input stream into "chunks" of a defined size.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/echo.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/echo.md
@@ -1,4 +1,8 @@
-# `echo`
+---
+sidebar_label: echo
+---
+
+# `echo` Command
 
 The `echo` command sends the provided message downstream.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/env.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/env.md
@@ -1,4 +1,8 @@
-# `env`
+---
+sidebar_label: env
+---
+
+# `env` Command
 
 The `env` command retrieves environment variables and passes it to the output stream.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/flatten.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/flatten.md
@@ -1,4 +1,8 @@
-# `flatten`
+---
+sidebar_label: flatten
+---
+
+# `flatten` Command
 
 The `flatten` command combines groups of elements from the input stream into a stream of individual elements, preserving their original order.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/head.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/head.md
@@ -1,4 +1,8 @@
-# `head`
+---
+sidebar_label: head
+---
+
+# `head` Command
 
 The `head` command returns the first `n` elements of the input stream and discards the remainder of the stream.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/help.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/help.md
@@ -1,4 +1,8 @@
-# `help`
+---
+sidebar_label: help
+---
+
+# `help` Command
 
 The `help` commands outputs a list of all CLI commands when no argument is provided.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/jq.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/jq.md
@@ -1,4 +1,8 @@
-# `jq`
+---
+sidebar_label: jq
+---
+
+# `jq` Command
 
 The `jq` command filters and processes JSON input.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/json.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/json.md
@@ -1,4 +1,8 @@
-# `json`
+---
+sidebar_label: json
+---
+
+# `json` Command
 
 The `json` command parses JSON input.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/sleep.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/sleep.md
@@ -1,4 +1,8 @@
-# `sleep`
+---
+sidebar_label: sleep
+---
+
+# `sleep` Command
 
 The `sleep` command suspends execution for a defined interval of time.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/tail.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/tail.md
@@ -1,4 +1,8 @@
-# `tail`
+---
+sidebar_label: tail
+---
+
+# `tail` Command
 
 The `tail` command returns the last `n` elements of the input stream. The beginning of the stream is consumed but discarded.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/uniq.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/uniq.md
@@ -1,4 +1,8 @@
-# `uniq`
+---
+sidebar_label: uniq
+---
+
+# `uniq` Command
 
 The `uniq` command deduplicates input stream objects.
 

--- a/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/write.md
+++ b/versioned_docs/version-2.X/reference/cli/miscellaneous-commands/write.md
@@ -1,4 +1,8 @@
-# `write`
+---
+sidebar_label: write
+---
+
+# `write` Command
 
 The `write` command outputs data to a file.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/aggregate.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/aggregate.md
@@ -1,4 +1,8 @@
-# `aggregate`
+---
+sidebar_label: aggregate
+---
+
+# `aggregate` Command
 
 The `aggregate` command aggregates query results over given properties and applies the defined aggregation functions.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/ancestors.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/ancestors.md
@@ -1,4 +1,8 @@
-# `ancestors`
+---
+sidebar_label: ancestors
+---
+
+# `ancestors` Command
 
 The `ancestors` command selects all ancestors of nodes returned in a query.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/count.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/count.md
@@ -1,4 +1,8 @@
-# `count`
+---
+sidebar_label: count
+---
+
+# `count` Command
 
 The `count` command returns the number of elements or properties in the piped input.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/descendants.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/descendants.md
@@ -1,4 +1,8 @@
-# `descendants`
+---
+sidebar_label: descendants
+---
+
+# `descendants` Command
 
 The `descendants` command selects all descendants of nodes returned in a query.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/kinds.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/kinds.md
@@ -1,4 +1,8 @@
-# `kinds`
+---
+sidebar_label: kinds
+---
+
+# `kinds` Command
 
 The `kinds` command retrieves information about the graph data kinds.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/predecessors.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/predecessors.md
@@ -1,4 +1,8 @@
-# `predecessors`
+---
+sidebar_label: predecessors
+---
+
+# `predecessors` Command
 
 The `predecessors` command selects all predecessors of nodes returned in a query.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/search.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/search.md
@@ -1,4 +1,8 @@
-# `search`
+---
+sidebar_label: search
+---
+
+# `search` Command
 
 The `search` command allows you to search the graph using [filters](../../search/filters.md), [traversals](../../search/traversals.md), and [functions](../../search/aggregation.md).
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/successors.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/successors.md
@@ -1,4 +1,8 @@
-# `successors`
+---
+sidebar_label: successors
+---
+
+# `successors` Command
 
 The `successors` command selects all successors of nodes returned in a query.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/templates/add.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/templates/add.md
@@ -2,7 +2,7 @@
 sidebar_label: add
 ---
 
-# `templates add`
+# `templates add` Command
 
 The `templates add` command adds a search template.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/templates/delete.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/templates/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `templates delete`
+# `templates delete` Command
 
 The `templates delete` command deletes a search template.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/templates/index.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/templates/index.md
@@ -1,4 +1,8 @@
-# `templates`
+---
+sidebar_label: templates
+---
+
+# `templates` Command
 
 The `templates` command is used to access the search template library.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/templates/test.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/templates/test.md
@@ -2,7 +2,7 @@
 sidebar_label: test
 ---
 
-# `templates test`
+# `templates test` Command
 
 The `templates test` command tests a search template.
 

--- a/versioned_docs/version-2.X/reference/cli/search-commands/templates/update.md
+++ b/versioned_docs/version-2.X/reference/cli/search-commands/templates/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `templates update`
+# `templates update` Command
 
 The `templates update` command updates a search template.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/certificate.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/certificate.md
@@ -1,4 +1,8 @@
-# `certificate`
+---
+sidebar_label: certificate
+---
+
+# `certificate` Command
 
 The `certificate` command is used to create a new TLS certificate and key pair based on the internal root CA certificate. This can be used to create a self-signed certificate for additional components that communicate with Resoto.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/delete.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/delete.md
@@ -2,7 +2,7 @@
 sidebar_label: delete
 ---
 
-# `configs delete`
+# `configs delete` Command
 
 The `configs delete` command deletes the specified configuration.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/edit.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/edit.md
@@ -2,7 +2,7 @@
 sidebar_label: edit
 ---
 
-# `configs edit`
+# `configs edit` Command
 
 The `configs edit` command opens the specified configuration in the locally configured text editor. Changes to the configuration will be updated, when the local file is saved and the editor has exited. It is possible to cancel an update, by not saving the file.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/index.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/index.md
@@ -1,4 +1,8 @@
-# `configs`
+---
+sidebar_label: configs
+---
+
+# `configs` Command
 
 The `configs` command allows for the management of component configurations.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/list.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/list.md
@@ -2,7 +2,7 @@
 sidebar_label: list
 ---
 
-# `configs list`
+# `configs list` Command
 
 The `configs list` command lists all configuration identifiers.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/set.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/set.md
@@ -2,7 +2,7 @@
 sidebar_label: set
 ---
 
-# `configs set`
+# `configs set` Command
 
 The `configs set` command assigns values to specific properties in the specified configuration.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/show.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/show.md
@@ -2,7 +2,7 @@
 sidebar_label: show
 ---
 
-# `configs show`
+# `configs show` Command
 
 The `configs show` command shows the specified configuration.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/configs/update.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/configs/update.md
@@ -2,7 +2,7 @@
 sidebar_label: update
 ---
 
-# `configs update`
+# `configs update` Command
 
 The `configs update` command updates the specified configuration, creating it if it does not already exist.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/system/backup/create.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/system/backup/create.md
@@ -2,7 +2,7 @@
 sidebar_label: create
 ---
 
-# `system backup create`
+# `system backup create` Command
 
 The `system backup create` command creates a backup of the database.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/system/backup/index.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/system/backup/index.md
@@ -1,4 +1,8 @@
-# `system backup`
+---
+sidebar_label: backup
+---
+
+# `system backup` Command
 
 The `system backup` command allows for creating and restoring backups.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/system/backup/restore.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/system/backup/restore.md
@@ -2,7 +2,7 @@
 sidebar_label: restore
 ---
 
-# `system backup restore`
+# `system backup restore` Command
 
 The `system backup restore` command restores a backup of the database.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/system/index.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/system/index.md
@@ -1,4 +1,8 @@
-# `system`
+---
+sidebar_label: system
+---
+
+# `system` Command
 
 The `system` command allows for the management of system-wide properties.
 

--- a/versioned_docs/version-2.X/reference/cli/setup-commands/system/info.md
+++ b/versioned_docs/version-2.X/reference/cli/setup-commands/system/info.md
@@ -2,7 +2,7 @@
 sidebar_label: info
 ---
 
-# `system info`
+# `system info` Command
 
 The `system info` command prints information about the system.
 


### PR DESCRIPTION
# Description

Clarifies that these are doc pages for commands (social cards only show the title, so they can be ambiguous/unclear without context).

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
