### PR TITLE
feat(docs): update edge API documentation

### DIFF
--- a/openapi/resotocore-edge.yml
+++ b/openapi/resotocore-edge.yml
@@ -1716,6 +1716,14 @@ paths:
             In case it is not defined or not set to false, every configuaration value is validated.
           schema:
             type: boolean
+        - name: dry_run
+          required: false
+          in: query
+          description: |
+            This parameter can be used to test if the config could be updated without really changing it.
+            It will perform all validations but not store the new value.
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:
@@ -1749,6 +1757,22 @@ paths:
           description: the identifier of the config to get.
           schema:
             type: string
+        - name: validate
+          required: false
+          in: query
+          description: |
+            This parameter can be used to turn off config validation.
+            In case it is not defined or not set to false, every configuaration value is validated.
+          schema:
+            type: boolean
+        - name: dry_run
+          required: false
+          in: query
+          description: |
+            This parameter can be used to test if the config could be patched without really changing it.
+            It will perform all validations but not store the new value.
+          schema:
+            type: boolean
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Updates `edge` Resoto Core API documentation to reflect changes in [`37fd663bf8466dda6d7a283fb9fa017ca1bf4455`](https://github.com/someengineering/resoto/commit/37fd663bf8466dda6d7a283fb9fa017ca1bf4455).