### PR TITLE
fix(docs): number Docker install steps and add note about download dir

### DIFF
--- a/versioned_docs/version-2.X/getting-started/install-resoto/docker.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/docker.md
@@ -14,6 +14,15 @@ import Tabs from '@theme/Tabs';
 
 [Docker](https://docker.com) provides the ability to run an application in a loosely isolated environment called a [container](https://docs.docker.com/get-started/overview#containers). For more information on Docker, please see the [official Docker documentation](https://docs.docker.com).
 
+Resoto consists of multiple [components](../../concepts/components/index.md) published as individual Docker images:
+
+- [`somecr.io/someengineering/resotocore`](https://hub.docker.com/repository/docker/someengineering/resotocore) maintains the infrastructure graph.
+- [`somecr.io/someengineering/resotoworker`](https://hub.docker.com/repository/docker/someengineering/resotoworker) collects infrastructure data from the cloud provider APIs.
+- [`somecr.io/someengineering/resotometrics`](https://hub.docker.com/repository/docker/someengineering/resotometrics) exports metrics in Prometheus format.
+- [`somecr.io/someengineering/resotoshell`](https://hub.docker.com/repository/docker/someengineering/resotoshell) provides the [command-line interface](../../reference/cli/index.md) used to interact with Resoto.
+
+https://youtu.be/U5L4z71WI-w
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-started#download-and-install-docker)
@@ -28,58 +37,53 @@ Resoto performs CPU-intensive graph operations. In a production setup, we recomm
 
 ## Installing Resoto
 
-https://youtu.be/U5L4z71WI-w
+1. Fetch the required files from the [`someengineering/resoto` GitHub repository](https://github.com/someengineering/resoto):
 
-Resoto consists of multiple [components](../../concepts/components/index.md) published as individual Docker images:
+   <Tabs>
+   <TabItem value="curl" label="curl">
 
-1. [`somecr.io/someengineering/resotocore`](https://hub.docker.com/repository/docker/someengineering/resotocore) maintains the infrastructure graph.
-2. [`somecr.io/someengineering/resotoworker`](https://hub.docker.com/repository/docker/someengineering/resotoworker) collects infrastructure data from the cloud provider APIs.
-3. [`somecr.io/someengineering/resotometrics`](https://hub.docker.com/repository/docker/someengineering/resotometrics) exports metrics in Prometheus format.
-4. [`somecr.io/someengineering/resotoshell`](https://hub.docker.com/repository/docker/someengineering/resotoshell) provides the [command-line interface](../../reference/cli/index.md) used to interact with Resoto.
+   ```bash
+   $ mkdir -p resoto/dockerV2
+   $ cd resoto
+   $ curl -o docker-compose.yaml https://raw.githubusercontent.com/someengineering/resoto/{{repoBranch}}/docker-compose.yaml
+   $ curl -o dockerV2/prometheus.yml https://raw.githubusercontent.com/someengineering/resoto/{{repoBranch}}/dockerV2/prometheus.yml
+   ```
 
-To install Resoto using [Docker Compose](https://docs.docker.com/compose), first fetch the required files from the [`someengineering/resoto` GitHub repository](https://github.com/someengineering/resoto):
+   </TabItem>
+   <TabItem value="git" label="git">
 
-<Tabs>
-<TabItem value="curl" label="curl">
+   ```bash
+   $ git clone https://github.com/someengineering/resoto.git
+   $ cd resoto
+   $ git checkout tags/{{repoBranch}}
+   ```
 
-```bash
-$ mkdir -p resoto/dockerV2
-$ cd resoto
-$ curl -o docker-compose.yaml https://raw.githubusercontent.com/someengineering/resoto/{{repoBranch}}/docker-compose.yaml
-$ curl -o dockerV2/prometheus.yml https://raw.githubusercontent.com/someengineering/resoto/{{repoBranch}}/dockerV2/prometheus.yml
-$ docker-compose up -d
-```
+   </TabItem>
+   </Tabs>
 
-</TabItem>
-<TabItem value="git" label="git">
+2. Start the services defined in the `docker-compose.yaml` file:
 
-```bash
-$ git clone https://github.com/someengineering/resoto.git
-$ cd resoto
-$ git checkout tags/{{repoBranch}}
-$ docker-compose up -d
-```
+   ```bash
+   $ docker-compose up -d
+   ```
 
-</TabItem>
-</Tabs>
+   Upon execution of `docker-compose up -d`, Docker Compose will start all components and set up the system. This process takes approximately 1-3 minutes, depending on your machine and internet connection.
 
-Upon execution of `docker-compose up -d`, Docker Compose will start all components and set up the system. This process takes approximately 1-3 minutes, depending on your machine and internet connection.
+   :::note
 
-:::note
+   [Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
 
-[Docker Compose V2 integrated compose functions in to the Docker platform.](https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command)
+   In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
 
-In Docker Compose V2, the command is `docker compose` (no hyphen) instead of `docker-compose`.
+   :::
 
-:::
+   :::info
 
-:::info
+   Resoto publishes packages for both x86 and ARM architectures for stable releases, but `edge` versions are only available for x86.
 
-Resoto publishes packages for both x86 and ARM architectures for stable releases, but `edge` versions are only available for x86.
+   If you have an Apple Silicon or other ARM-based machine, please use the latest stable release (<LatestRelease /> or `latest`).
 
-If you have an Apple Silicon or other ARM-based machine, please use the latest stable release (<LatestRelease /> or `latest`).
-
-:::
+   :::
 
 ## Launching the Command-Line Interface
 


### PR DESCRIPTION
# Description

Since the downloads dir fix is currently only in `main` and not a release branch, the note was only added to the `edge` docs.

If the change is cherrypicked to a release branch, the `2.4` versioned doc should also be updated.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
