### PR TITLE
fix: code highlighting for Ruby, C#, and PHP

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -349,7 +349,14 @@ const config = {
       prism: {
         theme: require('prism-react-renderer/themes/github'),
         darkTheme: require('./src/utils/prismDark.js'),
-        additionalLanguages: ['csv', 'ini', 'powershell'],
+        additionalLanguages: [
+          'csv',
+          'ini',
+          'powershell',
+          'ruby',
+          'csharp',
+          'php',
+        ],
       },
       magicComments: [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4118,9 +4118,9 @@ cosmiconfig@^6.0.0:
     yaml "^1.7.2"
 
 cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
-  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
+  integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
   dependencies:
     "@types/parse-json" "^4.0.0"
     import-fresh "^3.2.1"


### PR DESCRIPTION
# Description

Add code highlighting for Ruby, C#, and PHP.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
