### PR TITLE
fix(docs): dropdown background color

### DIFF
--- a/src/css/docusaurus-plugin-openapi-docs.css
+++ b/src/css/docusaurus-plugin-openapi-docs.css
@@ -1,3 +1,11 @@
+:root {
+  --openapi-input-background: rgb(246, 248, 250);
+}
+
+html[data-theme='dark'] {
+  --openapi-input-background: rgb(40, 42, 54);
+}
+
 /* Sidebar Method labels */
 .api-method > .menu__link {
   align-items: center;


### PR DESCRIPTION
# Description

Define value `--openapi-input-background` to fix dropdown background color in dark mode.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
