### PR TITLE
feat: show API method type in DocCards

### DIFF
--- a/src/css/docusaurus-plugin-openapi-docs.css
+++ b/src/css/docusaurus-plugin-openapi-docs.css
@@ -6,13 +6,17 @@ html[data-theme='dark'] {
   --openapi-input-background: rgb(40, 42, 54);
 }
 
-/* Sidebar Method labels */
-.api-method > .menu__link {
+/* Method labels */
+
+.api-method > .menu__link,
+.api-method > h2 {
+  display: flex;
   align-items: center;
   justify-content: start;
 }
 
-.api-method > .menu__link::before {
+.api-method > .menu__link::before,
+.api-method > h2::before {
   width: 50px;
   height: 20px;
   font-size: 12px;
@@ -21,39 +25,45 @@ html[data-theme='dark'] {
   font-weight: 600;
   border-radius: 0.25rem;
   border: 1px solid;
-  margin-right: var(--ifm-spacing-horizontal);
+  margin-right: calc(var(--ifm-spacing-horizontal) / 2);
   text-align: center;
   flex-shrink: 0;
   border-color: transparent;
   color: white;
 }
 
-.get > .menu__link::before {
+.get > .menu__link::before,
+.get > h2::before {
   content: 'get';
   background-color: var(--ifm-color-primary);
 }
 
-.post > .menu__link::before {
+.post > .menu__link::before,
+.post > h2::before {
   content: 'post';
   background-color: var(--openapi-code-green);
 }
 
-.delete > .menu__link::before {
-  content: 'del';
+.delete > .menu__link::before,
+.delete > h2::before {
+  content: 'delete';
   background-color: var(--openapi-code-red);
 }
 
-.put > .menu__link::before {
+.put > .menu__link::before,
+.put > h2::before {
   content: 'put';
   background-color: var(--openapi-code-blue);
 }
 
-.patch > .menu__link::before {
+.patch > .menu__link::before,
+.patch > h2::before {
   content: 'patch';
   background-color: var(--openapi-code-orange);
 }
 
-.head > .menu__link::before {
+.head > .menu__link::before,
+.head > h2::before {
   content: 'head';
   background-color: var(--ifm-color-secondary-darkest);
 }

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -1,0 +1,122 @@
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import Link from '@docusaurus/Link';
+import {
+  findFirstCategoryLink,
+  useDocById,
+} from '@docusaurus/theme-common/internal';
+import { translate } from '@docusaurus/Translate';
+import type { Props } from '@theme/DocCard';
+import clsx from 'clsx';
+import React, { type ReactNode } from 'react';
+
+import type {
+  PropSidebarItemCategory,
+  PropSidebarItemLink,
+} from '@docusaurus/plugin-content-docs';
+import styles from './styles.module.css';
+
+function CardContainer({
+  href,
+  children,
+  className,
+}: {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}): JSX.Element {
+  return (
+    <Link
+      href={href}
+      className={clsx('card padding--lg', styles.cardContainer, className)}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function CardLayout({
+  href,
+  icon,
+  title,
+  description,
+  className,
+}: {
+  href: string;
+  icon: ReactNode;
+  title: string;
+  description?: string;
+  className?: string;
+}): JSX.Element {
+  return (
+    <CardContainer href={href} className={className}>
+      <h2 className={clsx('text--truncate', styles.cardTitle)} title={title}>
+        {className?.includes('api-method') ? null : <>{icon} </>}
+        <span className="text--truncate">{title}</span>
+      </h2>
+      {description && (
+        <p
+          className={clsx('text--truncate', styles.cardDescription)}
+          title={description}
+        >
+          {description}
+        </p>
+      )}
+    </CardContainer>
+  );
+}
+
+function CardCategory({
+  item,
+}: {
+  item: PropSidebarItemCategory;
+}): JSX.Element | null {
+  const href = findFirstCategoryLink(item);
+
+  // Unexpected: categories that don't have a link have been filtered upfront
+  if (!href) {
+    return null;
+  }
+
+  return (
+    <CardLayout
+      href={href}
+      icon="🗃️"
+      title={item.label}
+      description={translate(
+        {
+          message: '{count} items',
+          id: 'theme.docs.DocCard.categoryDescription',
+          description:
+            'The default description for a category card in the generated index about how many items this category includes',
+        },
+        { count: item.items.length }
+      )}
+      className={item.className}
+    />
+  );
+}
+
+function CardLink({ item }: { item: PropSidebarItemLink }): JSX.Element {
+  const icon = isInternalUrl(item.href) ? '📄️' : '🔗';
+  const doc = useDocById(item.docId ?? undefined);
+  return (
+    <CardLayout
+      href={item.href}
+      icon={icon}
+      title={item.label}
+      description={doc?.description}
+      className={item.className}
+    />
+  );
+}
+
+export default function DocCard({ item }: Props): JSX.Element {
+  switch (item.type) {
+    case 'link':
+      return <CardLink item={item} />;
+    case 'category':
+      return <CardCategory item={item} />;
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`);
+  }
+}

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -1,0 +1,27 @@
+.cardContainer {
+  --ifm-link-color: var(--ifm-color-emphasis-800);
+  --ifm-link-hover-color: var(--ifm-color-emphasis-700);
+  --ifm-link-hover-decoration: none;
+
+  box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  transition: all var(--ifm-transition-fast) ease;
+  transition-property: border, box-shadow;
+}
+
+.cardContainer:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
+}
+
+.cardContainer *:last-child {
+  margin-bottom: 0;
+}
+
+.cardTitle {
+  font-size: 1.2rem;
+}
+
+.cardDescription {
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
# Description

Shows API method type in `DocCard` list, similar to how they are shown in the sidebar.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
