### PR TITLE
fix(docs): correct prev/next navigation & note that pip install not available for edge

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Concepts
 
 ```mdx-code-block

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Contributing
 
 ```mdx-code-block

--- a/docs/getting-started/configure-cloud-provider-access/index.md
+++ b/docs/getting-started/configure-cloud-provider-access/index.md
@@ -2,6 +2,7 @@
 sidebar_label: "2. Configure Cloud Provider Access"
 sidebar_position: 2
 pagination_prev: getting-started/install-resoto/index
+pagination_next: getting-started/next-steps
 ---
 
 # Configure Cloud Provider Access

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Getting Started
 
 ```mdx-code-block

--- a/docs/getting-started/install-resoto/aws/cdk.md
+++ b/docs/getting-started/install-resoto/aws/cdk.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Cloud Development Kit
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/docs/getting-started/install-resoto/aws/cloudformation.md
+++ b/docs/getting-started/install-resoto/aws/cloudformation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: CloudFormation
 sidebar_position: 1
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/docs/getting-started/install-resoto/docker.md
+++ b/docs/getting-started/install-resoto/docker.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Docker
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 
@@ -70,7 +70,7 @@ Resoto performs CPU-intensive graph operations. In a production setup, we recomm
 
    ```yaml
      resotoshell:
-       image: somecr.io/someengineering/resotoshell:edge
+       image: somecr.io/someengineering/resotoshell:{{imageTag}}
        container_name: resotoshell
        depends_on:
          - resotocore

--- a/docs/getting-started/install-resoto/index.md
+++ b/docs/getting-started/install-resoto/index.md
@@ -1,6 +1,8 @@
 ---
 sidebar_label: "1. Install Resoto"
 sidebar_position: 1
+pagination_prev: getting-started/index
+pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 
 # Install Resoto

--- a/docs/getting-started/install-resoto/kubernetes.md
+++ b/docs/getting-started/install-resoto/kubernetes.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Kubernetes
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/docs/getting-started/install-resoto/pip.md
+++ b/docs/getting-started/install-resoto/pip.md
@@ -1,17 +1,31 @@
 ---
 sidebar_label: pip
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 
 # Install Resoto with pip
 
 ```mdx-code-block
+import LatestRelease from '@site/src/components/LatestRelease';
+import VersionOnly from '@site/src/components/VersionOnly';
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 ```
 
 [pip](https://pip.pypa.io) is the package installer for [Python](https://www.python.org) and allows for easy installation of [Python](https://www.python.org) packages in Linux environments.
+
+<VersionOnly allowed="current">
+
+:::info
+
+**The `edge` version of Resoto is not installable with [pip](https://pip.pypa.io).**
+
+The below instructions will install the latest stable version of Resoto (<LatestRelease />).
+
+:::
+
+</VersionOnly>
 
 ## Prerequisites
 
@@ -42,7 +56,7 @@ $ cd ~/resoto
 $ python3 -m venv resoto-venv      # Create a virtual Python environment.
 $ source resoto-venv/bin/activate  # Activate the virtual Python environment.
 $ python -m ensurepip --upgrade    # Ensure pip is available.
-$ pip install -U resotocore resotoworker resotometrics resotoshell resoto-plugins
+$ pip install -U resotocore=={{nonEdgeImageTag}} resotoworker=={{nonEdgeImageTag}} resotometrics=={{nonEdgeImageTag}} resotoshell=={{nonEdgeImageTag}} resoto-plugins=={{nonEdgeImageTag}}
 # Generate two random passphrases. One to secure the graph database and one to secure resotocore with.
 $ echo $(LC_ALL=C tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 20) > .graphdb-password
 $ echo $(LC_ALL=C tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 20) > .pre-shared-key

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # How-To Guides
 
 ```mdx-code-block

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ---
 id: overview
 title: Documentation
+pagination_prev: null
+pagination_next: null
 ---
 
 # Overview

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Reference
 
 ```mdx-code-block

--- a/package.json
+++ b/package.json
@@ -61,11 +61,11 @@
     "eslint-plugin-formatjs": "4.3.4",
     "eslint-plugin-jsx-a11y": "6.6.1",
     "eslint-plugin-prettier": "4.2.1",
-    "eslint-plugin-react": "7.31.10",
+    "eslint-plugin-react": "7.31.11",
     "husky": "8.0.2",
     "lint-staged": "13.0.3",
     "prettier": "2.7.1",
-    "svgo": "3.0.1",
+    "svgo": "3.0.2",
     "typescript": "4.9.3"
   },
   "browserslist": {

--- a/src/components/SectionedDocCardList.tsx
+++ b/src/components/SectionedDocCardList.tsx
@@ -45,9 +45,7 @@ export default function SectionedDocCardList(props: Props): JSX.Element {
             </h2>
             <DocCardList items={item.items} className={className} />
           </>
-        ) : (
-          <strong>hello!</strong>
-        )
+        ) : null
       )}
     </>
   );

--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -1,6 +1,7 @@
 import type { PropVersionMetadata } from '@docusaurus/plugin-content-docs';
 import { useDocsVersion } from '@docusaurus/theme-common/internal';
 import latestRelease from '@site/latestRelease.json';
+import versions from '@site/versions.json';
 import OriginalCodeBlock from '@theme-original/CodeBlock';
 import type CodeBlockType from '@theme/CodeBlock';
 import React, { ComponentProps } from 'react';
@@ -26,6 +27,10 @@ export default function CodeBlock(props: Props): JSX.Element {
       {props.children
         .toString()
         .replace(/{{imageTag}}/g, versionTag ?? 'edge')
+        .replace(
+          /{{nonEdgeImageTag}}/g,
+          versionTag ?? latestRelease[versions[0]].version
+        )
         .replace(/{{repoBranch}}/g, versionTag ?? 'main')}
     </OriginalCodeBlock>
   );

--- a/versioned_docs/version-2.X/concepts/index.md
+++ b/versioned_docs/version-2.X/concepts/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Concepts
 
 ```mdx-code-block

--- a/versioned_docs/version-2.X/contributing/index.md
+++ b/versioned_docs/version-2.X/contributing/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Contributing
 
 ```mdx-code-block

--- a/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/index.md
+++ b/versioned_docs/version-2.X/getting-started/configure-cloud-provider-access/index.md
@@ -2,6 +2,7 @@
 sidebar_label: "2. Configure Cloud Provider Access"
 sidebar_position: 2
 pagination_prev: getting-started/install-resoto/index
+pagination_next: getting-started/next-steps
 ---
 
 # Configure Cloud Provider Access

--- a/versioned_docs/version-2.X/getting-started/index.md
+++ b/versioned_docs/version-2.X/getting-started/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Getting Started
 
 ```mdx-code-block

--- a/versioned_docs/version-2.X/getting-started/install-resoto/aws/cdk.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/aws/cdk.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Cloud Development Kit
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/versioned_docs/version-2.X/getting-started/install-resoto/aws/cloudformation.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/aws/cloudformation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_label: CloudFormation
 sidebar_position: 1
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/versioned_docs/version-2.X/getting-started/install-resoto/docker.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/docker.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Docker
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/versioned_docs/version-2.X/getting-started/install-resoto/index.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/index.md
@@ -1,6 +1,8 @@
 ---
 sidebar_label: "1. Install Resoto"
 sidebar_position: 1
+pagination_prev: getting-started/index
+pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 
 # Install Resoto

--- a/versioned_docs/version-2.X/getting-started/install-resoto/kubernetes.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/kubernetes.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Kubernetes
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 

--- a/versioned_docs/version-2.X/getting-started/install-resoto/pip.md
+++ b/versioned_docs/version-2.X/getting-started/install-resoto/pip.md
@@ -1,17 +1,31 @@
 ---
 sidebar_label: pip
-pagination_prev: getting-started/index
+pagination_prev: getting-started/install-resoto/index
 pagination_next: getting-started/configure-cloud-provider-access/index
 ---
 
 # Install Resoto with pip
 
 ```mdx-code-block
+import LatestRelease from '@site/src/components/LatestRelease';
+import VersionOnly from '@site/src/components/VersionOnly';
 import TabItem from '@theme/TabItem';
 import Tabs from '@theme/Tabs';
 ```
 
 [pip](https://pip.pypa.io) is the package installer for [Python](https://www.python.org) and allows for easy installation of [Python](https://www.python.org) packages in Linux environments.
+
+<VersionOnly allowed="current">
+
+:::info
+
+**The `edge` version of Resoto is not installable with [pip](https://pip.pypa.io).**
+
+The below instructions will install the latest stable version of Resoto (<LatestRelease />).
+
+:::
+
+</VersionOnly>
 
 ## Prerequisites
 
@@ -42,7 +56,7 @@ $ cd ~/resoto
 $ python3 -m venv resoto-venv      # Create a virtual Python environment.
 $ source resoto-venv/bin/activate  # Activate the virtual Python environment.
 $ python -m ensurepip --upgrade    # Ensure pip is available.
-$ pip install -U resotocore resotoworker resotometrics resotoshell resoto-plugins
+$ pip install -U resotocore=={{nonEdgeImageTag}} resotoworker=={{nonEdgeImageTag}} resotometrics=={{nonEdgeImageTag}} resotoshell=={{nonEdgeImageTag}} resoto-plugins=={{nonEdgeImageTag}}
 # Generate two random passphrases. One to secure the graph database and one to secure resotocore with.
 $ echo $(LC_ALL=C tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 20) > .graphdb-password
 $ echo $(LC_ALL=C tr -dc _A-Z-a-z-0-9 < /dev/urandom | head -c 20) > .pre-shared-key

--- a/versioned_docs/version-2.X/how-to-guides/index.md
+++ b/versioned_docs/version-2.X/how-to-guides/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # How-To Guides
 
 ```mdx-code-block

--- a/versioned_docs/version-2.X/index.md
+++ b/versioned_docs/version-2.X/index.md
@@ -1,6 +1,8 @@
 ---
 id: overview
 title: Documentation
+pagination_prev: null
+pagination_next: null
 ---
 
 # Overview

--- a/versioned_docs/version-2.X/reference/index.md
+++ b/versioned_docs/version-2.X/reference/index.md
@@ -1,3 +1,8 @@
+---
+pagination_prev: null
+pagination_next: null
+---
+
 # Reference
 
 ```mdx-code-block

--- a/yarn.lock
+++ b/yarn.lock
@@ -3152,7 +3152,7 @@ array-ify@^1.0.0:
   resolved "https://registry.yarnpkg.com/array-ify/-/array-ify-1.0.0.tgz#9e528762b4a9066ad163a6962a364418e9626ece"
   integrity sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==
 
-array-includes@^3.1.5:
+array-includes@^3.1.5, array-includes@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
   integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
@@ -3168,7 +3168,7 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-array.prototype.flatmap@^1.3.0:
+array.prototype.flatmap@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
   integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
@@ -3177,6 +3177,17 @@ array.prototype.flatmap@^1.3.0:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
+
+array.prototype.tosorted@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz#ccf44738aa2b5ac56578ffda97c03fd3e23dd532"
+  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.1.3"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -5442,25 +5453,26 @@ eslint-plugin-prettier@4.2.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react@7.31.10:
-  version "7.31.10"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz#6782c2c7fe91c09e715d536067644bbb9491419a"
-  integrity sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==
+eslint-plugin-react@7.31.11:
+  version "7.31.11"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz#011521d2b16dcf95795df688a4770b4eaab364c8"
+  integrity sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==
   dependencies:
-    array-includes "^3.1.5"
-    array.prototype.flatmap "^1.3.0"
+    array-includes "^3.1.6"
+    array.prototype.flatmap "^1.3.1"
+    array.prototype.tosorted "^1.1.1"
     doctrine "^2.1.0"
     estraverse "^5.3.0"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
     minimatch "^3.1.2"
-    object.entries "^1.1.5"
-    object.fromentries "^2.0.5"
-    object.hasown "^1.1.1"
-    object.values "^1.1.5"
+    object.entries "^1.1.6"
+    object.fromentries "^2.0.6"
+    object.hasown "^1.1.2"
+    object.values "^1.1.6"
     prop-types "^15.8.1"
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
-    string.prototype.matchall "^4.0.7"
+    string.prototype.matchall "^4.0.8"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -8463,7 +8475,7 @@ object.assign@^4.1.0, object.assign@^4.1.3, object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-object.entries@^1.1.5:
+object.entries@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
   integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
@@ -8472,7 +8484,7 @@ object.entries@^1.1.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.fromentries@^2.0.5:
+object.fromentries@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.6.tgz#cdb04da08c539cffa912dcd368b886e0904bfa73"
   integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
@@ -8481,7 +8493,7 @@ object.fromentries@^2.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.hasown@^1.1.1:
+object.hasown@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
   integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
@@ -8489,7 +8501,7 @@ object.hasown@^1.1.1:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.values@^1.1.5:
+object.values@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
   integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
@@ -10557,7 +10569,7 @@ string-width@^5.0.0, string-width@^5.0.1:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-string.prototype.matchall@^4.0.7:
+string.prototype.matchall@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
   integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
@@ -10743,10 +10755,10 @@ svg-parser@^2.0.4:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svgo@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.1.tgz#873f3341d04a08980ad8366780e8d04143b9fc2c"
-  integrity sha512-6kiDrstRCmA600TySGBu4VNA/FdEriOv7PKQRDOyIaVYUNamWvDSZjgMsM+mB0r0y5T7S3P5DkZJSIBQ/9QEsg==
+svgo@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.2.tgz#5e99eeea42c68ee0dc46aa16da093838c262fe0a"
+  integrity sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==
   dependencies:
     "@trysound/sax" "0.2.0"
     commander "^7.2.0"


### PR DESCRIPTION
# Description

- Remove/correct navigation on some docs pages
- Note that pip can only be used to install tagged versions, and specify version in command
- Remove debugging code for `SectionedDocCardList` component

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
