### PR TITLE
fix: capture referrer URL in email signup form & add console logging to serverless function

### DIFF
--- a/netlify/functions/submission-created.ts
+++ b/netlify/functions/submission-created.ts
@@ -5,6 +5,7 @@ import fetch from 'node-fetch';
 const handler: Handler = async (event: HandlerEvent) => {
   const { BUTTONDOWN_API_KEY } = process.env;
   const email = JSON.parse(event.body ?? '').payload.email;
+  const referrer_url = JSON.parse(event.body ?? '').payload.referrer_url;
 
   console.log(`Received email signup form submission: ${email}`);
 
@@ -13,7 +14,7 @@ const handler: Handler = async (event: HandlerEvent) => {
       'https://api.buttondown.email/v1/subscribers',
       {
         method: 'post',
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, referrer_url }),
         headers: {
           Authorization: `Token ${BUTTONDOWN_API_KEY}`,
           'Content-Type': 'application/json',
@@ -22,7 +23,9 @@ const handler: Handler = async (event: HandlerEvent) => {
     );
     const data = await response.json();
 
-    console.log(`Sent email signup request to Buttondown: ${data}`);
+    console.log(
+      `Sent email signup request to Buttondown: ${JSON.stringify(data)}`
+    );
 
     return {
       statusCode: 200,

--- a/netlify/functions/submission-created.ts
+++ b/netlify/functions/submission-created.ts
@@ -2,8 +2,10 @@ import { Handler, HandlerEvent } from '@netlify/functions';
 import fetch from 'node-fetch';
 
 const handler: Handler = async (event: HandlerEvent) => {
-  const email = JSON.parse(event.body ?? '').payload.email;
   const { BUTTONDOWN_API_KEY } = process.env;
+  const email = JSON.parse(event.body ?? '').payload.email;
+
+  console.log(`Received email signup form submission: ${email}`);
 
   try {
     const response = await fetch(
@@ -19,11 +21,15 @@ const handler: Handler = async (event: HandlerEvent) => {
     );
     const data = await response.json();
 
+    console.log(`Sent email signup request to Buttondown: ${data}`);
+
     return {
       statusCode: 200,
       body: JSON.stringify({ data }),
     };
   } catch (error) {
+    console.log(`Error sending email signup request to Buttondown: ${error}`);
+
     return { statusCode: 422, body: JSON.stringify({ error }) };
   }
 };

--- a/netlify/functions/submission-created.ts
+++ b/netlify/functions/submission-created.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Handler, HandlerEvent } from '@netlify/functions';
 import fetch from 'node-fetch';
 

--- a/src/components/NewsletterSignupForm/index.tsx
+++ b/src/components/NewsletterSignupForm/index.tsx
@@ -1,3 +1,4 @@
+import useIsBrowser from '@docusaurus/useIsBrowser';
 import clsx from 'clsx';
 import { useFormik } from 'formik';
 import React from 'react';
@@ -11,6 +12,8 @@ import * as Yup from 'yup';
 import styles from './index.module.css';
 
 export default function NewsletterSignupForm(): JSX.Element {
+  const isBrowser = useIsBrowser();
+
   const netlify = useNetlifyForm({
     name: 'newsletter-signup',
     honeypotName: 'bot-field',
@@ -19,9 +22,13 @@ export default function NewsletterSignupForm(): JSX.Element {
       console.log('Successfully sent form data to Netlify Server');
     },
   });
+
   const { handleSubmit, handleChange, handleBlur, touched, errors, values } =
     useFormik({
-      initialValues: { email: '' },
+      initialValues: {
+        email: '',
+        referrer_url: isBrowser ? window.location.href : '',
+      },
       onSubmit: (values) => netlify.handleSubmit(null, values),
       validationSchema: Yup.object().shape({
         email: Yup.string()

--- a/src/components/NewsletterSignupForm/index.tsx
+++ b/src/components/NewsletterSignupForm/index.tsx
@@ -1,7 +1,6 @@
-import useIsBrowser from '@docusaurus/useIsBrowser';
 import clsx from 'clsx';
 import { useFormik } from 'formik';
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Honeypot,
   NetlifyFormComponent,
@@ -12,8 +11,6 @@ import * as Yup from 'yup';
 import styles from './index.module.css';
 
 export default function NewsletterSignupForm(): JSX.Element {
-  const isBrowser = useIsBrowser();
-
   const netlify = useNetlifyForm({
     name: 'newsletter-signup',
     honeypotName: 'bot-field',
@@ -27,7 +24,7 @@ export default function NewsletterSignupForm(): JSX.Element {
     useFormik({
       initialValues: {
         email: '',
-        referrer_url: isBrowser ? window.location.href : '',
+        referrer_url: '',
       },
       onSubmit: (values) => netlify.handleSubmit(null, values),
       validationSchema: Yup.object().shape({
@@ -37,6 +34,10 @@ export default function NewsletterSignupForm(): JSX.Element {
           .email('Please provide a valid email address'),
       }),
     });
+
+  useEffect(() => {
+    values.referrer_url = window.location.href;
+  }, []);
 
   return (
     <NetlifyFormProvider {...netlify}>

--- a/src/components/NewsletterSignupForm/index.tsx
+++ b/src/components/NewsletterSignupForm/index.tsx
@@ -57,6 +57,12 @@ export default function NewsletterSignupForm(): JSX.Element {
           </p>
         ) : (
           <>
+            <input
+              type="hidden"
+              name="referrer_url"
+              id="referrer_url"
+              value={values.referrer_url}
+            />
             <label htmlFor="email">Email address</label>
             <div>
               <input

--- a/src/components/NewsletterSignupForm/index.tsx
+++ b/src/components/NewsletterSignupForm/index.tsx
@@ -57,12 +57,6 @@ export default function NewsletterSignupForm(): JSX.Element {
           </p>
         ) : (
           <>
-            <input
-              type="hidden"
-              name="referrer_url"
-              id="referrer_url"
-              value={values.referrer_url}
-            />
             <label htmlFor="email">Email address</label>
             <div>
               <input
@@ -85,6 +79,12 @@ export default function NewsletterSignupForm(): JSX.Element {
             <p className={clsx(styles.error)} aria-live="polite">
               {touched.email ? errors.email : <>&nbsp;</>}
             </p>
+            <input
+              type="hidden"
+              name="referrer_url"
+              id="referrer_url"
+              value={values.referrer_url}
+            />
           </>
         )}
       </NetlifyFormComponent>


### PR DESCRIPTION
# Description

For debugging purposes; email signup seems broken at the moment.

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
