### PR TITLE
fix: set swRegister to false

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,6 +168,7 @@ const config = {
       /** @type {import('@docusaurus/plugin-pwa').PluginOptions} */
       {
         debug: !isProd,
+        swRegister: false,
         swCustom: require.resolve('./src/sw.js'),
         pwaHead: [
           {


### PR DESCRIPTION
# Description

Set `swRegister` to `false` in Docusaurus PWA plugin config.


# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
