### PR TITLE
fix(docs): missing API sidebar entries

### DIFF
--- a/versioned_sidebars/version-3.X-sidebars.json
+++ b/versioned_sidebars/version-3.X-sidebars.json
@@ -91,6 +91,12 @@
                 },
                 {
                   "type": "doc",
+                  "id": "reference/api/show-the-structure-of-the-search",
+                  "label": "Show the structure of the search",
+                  "className": "api-method post"
+                },
+                {
+                  "type": "doc",
                   "id": "reference/api/explain-the-search-execution-plan",
                   "label": "Explain the search execution plan",
                   "className": "api-method post"
@@ -475,6 +481,12 @@
                   "type": "doc",
                   "id": "reference/api/perform-a-benchmark-on-a-graph",
                   "label": "Perform a benchmark on a graph.",
+                  "className": "api-method get"
+                },
+                {
+                  "type": "doc",
+                  "id": "reference/api/list-all-resources-that-match-a-given-check",
+                  "label": "List all resources that match a given check.",
                   "className": "api-method get"
                 },
                 {


### PR DESCRIPTION
# Description

Versioned sidebars need to be manually updated when API routes are added/removed.

# Docs Version(s)

- [ ] `edge`
- [x] `3.X`
- [ ] `2.X`

# To-Dos

- [x] Format with `yarn format`
- [x] Lint with `yarn lint`
- [x] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
