### PR TITLE
fix(compare): edit AWS Config comparison chart

### DIFF
--- a/compare/aws-config.mdx
+++ b/compare/aws-config.mdx
@@ -28,7 +28,7 @@ Resoto, on the other hand, also supports [Kubernetes](/docs/how-to-guides/data-s
 
 |  | Resoto | AWS Config |
 | --- | --- | --- |
-| **Coverage** | Offers support for over 200 [AWS resources](/docs/reference/unified-data-model/aws) and supports all AWS regions. | Only covers 120 AWS resources, not all of which are supported in every AWS region. |
+| **Coverage** | Offers support for over 204 [AWS resource types](/docs/reference/unified-data-model/aws) and supports all AWS regions. | Covers 204 AWS resource types, not all of which are supported in every AWS region. |
 | **Multi-Cloud** | Cloud agnostic and can be used as a single control plane for multiple clouds.<br /><br />Open source and offers an SDK that makes it easy to add support for additional platforms and resources (e.g., on-prem or SaaS). | Purpose-built for AWS. |
 | **Full-Text Search** | Creates an [inventory](/docs/concepts/asset-inventory-graph) of discovered resources and offers [full-text search](/docs/reference/search/full-text) as an easy way to explore your cloud inventory. | Does not offer full-text search. |
 | **Resource Visualization** | Offers [dashboards](/docs/reference/user-interface/dashboards) for visual exploration of resources and their relationships.<br /><br />Also includes a graph view, which depicts how resources are connected. | Part of the general [AWS Console](https://aws.amazon.com/console) experience.<br /><br />To visualize data, needs to be integrated with S3 for storage, Athena for querying, and Quicksight for dashboards. |


### PR DESCRIPTION
updated the number of resource types that both Config and Resoto support. I changed it from "resources" to "resource types".

# Description

<!-- Please describe the changes included in this PR here. -->

# Docs Version(s)

<!-- The Resoto documentation is versioned. (Please see https://docusaurus.io/docs/versioning for details.) -->
<!-- Add an 'x' between the brackets to mark each version of the docs modified in this PR. -->
<!-- (Feel free to remove this section if this PR does not include docs changes.) -->

- [ ] `edge`
- [ ] `3.X`

# To-Dos

<!-- Before submitting this PR, please format, lint, and build your changes locally. -->
<!-- Add an 'x' between the brackets to mark each task as completed. -->
<!-- (Feel free to remove any items that do not apply to this PR.) -->

- [ ] Format with `yarn format`
- [ ] Lint with `yarn lint`
- [ ] Build successfully with `yarn build`

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
